### PR TITLE
Add cookie jar support to `test create` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 1.0.6 - 2018-04-14
+
+* The `calibre test create` command now accepts a --cookie-jar flag. It‘ll use a netscape formatted cookie-jar for a given test.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -344,6 +344,15 @@
         "xdg-basedir": "3.0.0"
       }
     },
+    "cookiefile": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/cookiefile/-/cookiefile-1.0.10.tgz",
+      "integrity": "sha1-zijhtcEfViAqqcHbWpl0HqDl0yg=",
+      "requires": {
+        "file-exists": "2.0.0",
+        "isnumeric": "0.3.3"
+      }
+    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -569,6 +578,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "file-exists": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-2.0.0.tgz",
+      "integrity": "sha1-okFQZlFQ5i1VvFRJKB2I0rCBDco="
     },
     "find-up": {
       "version": "2.1.0",
@@ -891,6 +905,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isnumeric": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.3.3.tgz",
+      "integrity": "sha512-GTxMCA0SsHdQWdsb6CDavRbeq4mQ2pryJUqwpcRHfKNnvdnNnI+3zT8K2zR/o9zZxTM6HKW7GRRetObb8E7p9Q=="
     },
     "isstream": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "engines": {
     "node": "> 7.6.0"
   },
@@ -13,6 +13,7 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "columnify": "^1.5.4",
+    "cookiefile": "^1.0.10",
     "date-fns": "^1.28.5",
     "graphql-request": "^1.4.1",
     "humanize": "0.0.9",

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,8 +1,8 @@
 const gql = require('../utils/api-client')
 
 const CREATE_MUTATION = `
-  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag) {
-    createTest(url: $url, location: $location, device: $device, connection: $connection) {
+  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!]) {
+    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies) {
       uuid
     }
   }
@@ -69,13 +69,14 @@ const GET_BY_UUID = `
   }
 `
 
-const create = async ({ url, location, device, connection }) => {
+const create = async ({ url, location, device, connection, cookies }) => {
   try {
     const response = await gql.request(CREATE_MUTATION, {
       url,
       location,
       device,
-      connection
+      connection,
+      cookies
     })
 
     return response.createTest


### PR DESCRIPTION
The `calibre test create <url>` command now accepts a `--cookie-jar=path/to/cookie-jar-file` flag. 
It uses the [Netscape cookie format](https://crdx.org/cookies/). Tests will be run with those cookies set. 