### PR TITLE
Fix the Git URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/calibre/cli.git"
+    "url": "https://github.com/calibreapp/cli.git"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Following the GitHub link from your NPM page gives a 404 (and points to another user's account). This change fixes the URL.