### PR TITLE
1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.2.1 - 2019-02-21
+- Removed `await-for-of` to continue support for node 8.
+- Changed `download-artifact` commands to output relative directory of stored
+  artifacts.
+
 ### 1.2.0 - 2019-02-19
 
 - Added `calibre test download-artifact <uuid>` command.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "calibre",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
-    "node": "> 10.11.0"
+    "node": "> 8.15.0"
   },
   "description": "Calibre - Page speed performance testing with Google Lighthouse",
   "author": "calibreapp.com",

--- a/src/cli/site/download-snapshot-artifacts.js
+++ b/src/cli/site/download-snapshot-artifacts.js
@@ -50,12 +50,12 @@ const main = async args => {
       }
     ]
 
-    for await (const page of response.pages) {
+    for (const page of response.pages) {
       const pageDirectory = mkdirp(
         directories.concat([`${page.name}-${page.uuid}`])
       )
 
-      for await (const profile of response.testProfiles) {
+      for (const profile of response.testProfiles) {
         const test = response.snapshot.tests.find(
           test =>
             test.page.uuid == page.uuid && test.testProfile.uuid == profile.uuid
@@ -184,7 +184,7 @@ const main = async args => {
       }
     })
 
-    await new listr(tasks).run()
+    return new listr(tasks).run()
   } catch (error) {
     throw new Error(humaniseError(error))
   }

--- a/src/cli/site/download-snapshot-artifacts.js
+++ b/src/cli/site/download-snapshot-artifacts.js
@@ -184,7 +184,9 @@ const main = async args => {
       }
     })
 
-    return new listr(tasks).run()
+    await new listr(tasks).run()
+
+    console.log(`Saved artifacts to ${path.relative(process.cwd(), rootPath)}`)
   } catch (error) {
     throw new Error(humaniseError(error))
   }

--- a/src/cli/test/download-artifacts.js
+++ b/src/cli/test/download-artifacts.js
@@ -57,7 +57,7 @@ const main = async args => {
 
     await tasks.run()
 
-    console.log('Saved artifacts to', directory)
+    console.log(`Saved artifacts to ${path.relative(process.cwd(), directory)}`)
   } catch (e) {
     throw new Error(humaniseError(e))
   }


### PR DESCRIPTION
`download` returns a promise which is handled by `listr`, therefore `for-await-of` is not required.

Verified to be working with node 8.15.0
<img width="702" alt="screen shot 2019-02-21 at 12 57 46 pm" src="https://user-images.githubusercontent.com/785655/53137823-506c6580-35d8-11e9-9cd4-eac9936ade80.png">

This update will also output the relative download path upon completion:
<img width="374" alt="screen shot 2019-02-21 at 12 58 59 pm" src="https://user-images.githubusercontent.com/785655/53137866-78f45f80-35d8-11e9-80fb-2d3a781fc363.png">

Closes #41 