### PR TITLE
Remove --no-deprecation option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "engines": {
     "node": "> 8.15.0"
   },
@@ -38,12 +38,7 @@
     "test": "jest",
     "lint": "eslint ."
   },
-  "keywords": [
-    "performance",
-    "testing",
-    "test",
-    "lighthouse"
-  ],
+  "keywords": ["performance", "testing", "test", "lighthouse"],
   "license": "ISC",
   "repository": {
     "type": "git",
@@ -54,13 +49,7 @@
     "singleQuote": true
   },
   "pkg": {
-    "scripts": [
-      "src/**/*.js"
-    ],
-    "targets": [
-      "node10-linux-x64",
-      "node10-macos-x64",
-      "node10-win-x64"
-    ]
+    "scripts": ["src/**/*.js"],
+    "targets": ["node10-linux-x64", "node10-macos-x64", "node10-win-x64"]
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-deprecation
+#!/usr/bin/env node
 
 const updateNotifier = require('update-notifier')
 const chalk = require('chalk')


### PR DESCRIPTION
The `--no-deprecation` flag is preventing the file from executing in some cases.