### PR TITLE
 🐛 Fix get snapshot metrics csv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ env:
   - CALIBRE_API_TOKEN=xxx
 language: node_js
 node_js:
-  - node
-  - lts/*
+  - "11.10.1"
 script: npm run ci

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "engines": {
     "node": "> 8.15.0"
   },
@@ -38,12 +38,7 @@
     "test": "jest",
     "lint": "eslint ."
   },
-  "keywords": [
-    "performance",
-    "testing",
-    "test",
-    "lighthouse"
-  ],
+  "keywords": ["performance", "testing", "test", "lighthouse"],
   "license": "ISC",
   "repository": {
     "type": "git",
@@ -54,13 +49,7 @@
     "singleQuote": true
   },
   "pkg": {
-    "scripts": [
-      "src/**/*.js"
-    ],
-    "targets": [
-      "node10-linux-x64",
-      "node10-macos-x64",
-      "node10-win-x64"
-    ]
+    "scripts": ["src/**/*.js"],
+    "targets": ["node10-linux-x64", "node10-macos-x64", "node10-win-x64"]
   }
 }

--- a/src/cli/site/get-snapshot-metrics.js
+++ b/src/cli/site/get-snapshot-metrics.js
@@ -90,7 +90,7 @@ const main = async args => {
       })
     )
   } catch (e) {
-    if (args.json) {
+    if (args.json || args.csv) {
       console.error(e)
     } else {
       spinner.fail()

--- a/src/cli/site/get-snapshot-metrics.js
+++ b/src/cli/site/get-snapshot-metrics.js
@@ -23,8 +23,8 @@ const formatCSV = payload => {
         SnapshotSequenceId: payload.snapshot.sequenceId,
         TestProfileId: testProfile.id,
         TestProfileName: testProfile.name,
-        DeviceName: testProfile.device.title,
-        BandwidthName: testProfile.bandwidth.title,
+        DeviceName: testProfile.device && testProfile.device.title,
+        BandwidthName: testProfile.bandwidth && testProfile.bandwidth.title,
         isMobile: testProfile.isMobile,
         hasDeviceEmulation: testProfile.hasDeviceEmulation,
         hasBandwidthEmulation: testProfile.hasBandwidthEmulation


### PR DESCRIPTION
When outputting snapshot metrics as CSV we need to check if there's a device and/or bandwidth object.

When outputting snapshot metrics as CSV and an error is thrown we need to just return the error (same as JSON).