### PR TITLE
Updated examples/nodejs/get-all-pulse-metrics.js

### DIFF
--- a/examples/nodejs/get-all-pulse-metrics.js
+++ b/examples/nodejs/get-all-pulse-metrics.js
@@ -1,55 +1,32 @@
 #!/usr/bin/env node
 
-
 /*
+  calibre v1.2.3+ required
+  
   This example will fetch all sites from a given account,
-  then it will fetch the pulse metrics from each page.
-
-  calibre v1.1.0 required for this example.
+  then, the 7 days worth of consistently-interactive for each site
 */
 
-const {
-  Site,
-  Page,
-  SnapshotMetrics
-} = require('calibre')
+const { Site, SnapshotMetrics } = require('calibre')
 
 const main = async () => {
-  let allPulseMetrics = {}
   const sites = await Site.list()
 
   console.log(`=== ${sites.length} sites`)
 
-  await Promise.all(sites.map(async site => {
-    allPulseMetrics[site.slug] = {}
-
-    const pages = await Page.list({
-      site: site.slug
-    })
-
-    // Iterate through each page, returning a promise for the metrics being fetched
-    return Promise.all(pages.map(async page => {
-      const pulse = await SnapshotMetrics.pulse({
-        site: site.slug,
-        page: page.uuid,
+  const metrics = await Promise.all(
+    sites.map(({ slug }) => {
+      return SnapshotMetrics.pulse({
+        site: slug,
         durationInDays: 7,
         metrics: ['consistently-interactive']
       })
-
-      // Update the allPulseMetrics hash with metrics for this page
-      allPulseMetrics[site.slug][page.uuid] = {
-        page: page,
-        pulse: pulse
-      }
-
-      return pulse
-    }))
-  }))
-
+    })
+  )
 
   console.log('=== Logging formatted JSON metrics ===')
 
-  console.log(JSON.stringify(allPulseMetrics, null, 2))
+  console.log(JSON.stringify(metrics, null, 2))
 }
 
 main()


### PR DESCRIPTION
Updated the get-all-pulse-metrics example so that uses the latest version of CLI. 

Instead of fetching all sites, then all pages, we fetch all sites, then the metrics for each site asynchronously. 

It's faster, it's smaller. 🍃 