### PR TITLE
Log request result as JSON

### DIFF
--- a/__tests__/cli/__snapshots__/request.test.js.snap
+++ b/__tests__/cli/__snapshots__/request.test.js.snap
@@ -24,6 +24,12 @@ Examples:
 `;
 
 exports[`request returns response 1`] = `
-"{ organisation: { site: { slug: 'calibre' } } }
+"{
+  \\"organisation\\": {
+    \\"site\\": {
+      \\"slug\\": \\"calibre\\"
+    }
+  }
+}
 "
 `;

--- a/examples/nodejs/metrics-history.js
+++ b/examples/nodejs/metrics-history.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const { GraphQL } = require('calibre')
+
+const metricsHistory = async () => {
+  const query = `
+    query MetricsHistory($slug: String!, $measurement: MetricTag!, $page: String!){
+      organisation {
+        site(slug: $slug) {
+          metricsHistory(measurement: $measurement, page: $page) {
+            profileName
+            current
+            previous
+          }
+        }
+      }
+    }
+  `
+  const slug = 'calibre'
+  const measurement = 'consistently-interactive'
+  const page = 'c993aac8-2623-474c-b7d5-21e203f290e2'
+
+  try {
+    const result = await GraphQL.request({ query, slug, measurement, page })
+    console.log(JSON.stringify(result, null, 2))
+  } catch (e) {
+    console.log(JSON.stringify(e, null, 2))
+  }
+}
+
+metricsHistory()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "engines": {
     "node": "> 8.15.0"
   },

--- a/src/cli/request.js
+++ b/src/cli/request.js
@@ -18,7 +18,7 @@ const main = async args => {
   }
 
   spinner.stop()
-  console.log(result)
+  console.log(JSON.stringify(result, null, 2))
 }
 
 module.exports = {


### PR DESCRIPTION
Previously the following command would result in:

`calibre request --query='query GetMetricsHistory($slug: String!, $measurement: MetricTag!, $page: String!){organisation{site(slug:$slug){metricsHistory(measurement:$meas
urement, page:$page){current previous}}}}' --slug='apple' --measurement='firstRender' --page='5ee3470f-7890-4c8c-ba93-05adedfa3164'`

```
{ organisation: { site: { metricsHistory: [Array] } } }
```

Now it will result in:

```
{
  "organisation": {
    "site": {
      "metricsHistory": [
        {
          "current": 282,
          "previous": 370
        },
        {
          "current": 2824,
          "previous": 2985
        }
      ]
    }
  }
}
```