### PR TITLE
 Read errors from GraphQL extensions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.2 - 2019-05-20
+
+- Updated `api-error` util to get GraphQL errors from `extensions`
+
 ### 2.0.1 - 2019-05-17
 
 - Fixed test output to only display metric if available

--- a/__tests__/fixtures/createSiteError.json
+++ b/__tests__/fixtures/createSiteError.json
@@ -1,0 +1,28 @@
+{
+  "errors": [
+    {
+      "message": "Variable attributes of type SiteInput! was provided invalid value",
+      "locations": [
+        {
+          "line": 1,
+          "column": 44
+        }
+      ],
+      "problems": [
+        {
+          "path": [],
+          "explanation": "Expected value to not be null"
+        }
+      ],
+      "extensions": {
+        "value": null,
+        "problems": [
+          {
+            "path": [],
+            "explanation": "Expected value to not be null"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/__tests__/utils/__snapshots__/api-error.test.js.snap
+++ b/__tests__/utils/__snapshots__/api-error.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`apiError error 1`] = `"Expected Error"`;
+
+exports[`apiError error string 1`] = `"An unknown error occurred \\"Error string\\""`;
+
+exports[`apiError graphql 1`] = `"Expected value to not be null"`;
+
+exports[`apiError message 1`] = `"Expected Error Message"`;
+
+exports[`apiError messages 1`] = `"First Expected Error Message"`;

--- a/__tests__/utils/api-error.test.js
+++ b/__tests__/utils/api-error.test.js
@@ -1,0 +1,27 @@
+const { humaniseError } = require('../../src/utils/api-error')
+
+const erroredSite = require('../fixtures/createSiteError.json')
+
+describe('apiError', () => {
+  it('graphql', () => {
+    expect(humaniseError(erroredSite.errors)).toMatchSnapshot()
+  })
+
+  it('messages', () => {
+    const error = [{ message: 'First Expected Error Message' }]
+    expect(humaniseError(error)).toMatchSnapshot()
+  })
+
+  it('message', () => {
+    const error = { message: 'Expected Error Message' }
+    expect(humaniseError(error)).toMatchSnapshot()
+  })
+
+  it('error', () => {
+    expect(humaniseError(new Error('Expected Error'))).toMatchSnapshot()
+  })
+
+  it('error string', () => {
+    expect(humaniseError('Error string')).toMatchSnapshot()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "engines": {
     "node": "> 8.15.0"
   },

--- a/src/utils/api-error.js
+++ b/src/utils/api-error.js
@@ -7,10 +7,11 @@ const handleError = err => {
 const humaniseError = apiError => {
   if (
     apiError[0] &&
-    apiError[0].problems &&
-    apiError[0].problems[0].explanation
+    apiError[0].extensions &&
+    apiError[0].extensions.problems &&
+    apiError[0].extensions.problems[0].explanation
   ) {
-    return apiError[0].problems[0].explanation
+    return apiError[0].extensions.problems[0].explanation
   } else if (apiError[0] && apiError[0].message) {
     return apiError[0].message
   } else if (apiError.message) {


### PR DESCRIPTION
The Calibre GraphQL API has been updated and now returns errors in the `extensions` namespace. Errors are still returned in `problems` but this will be deprecated so this PR updates the `api-error` util to read errors from `extensions`.