### PR TITLE
Add headers to single page test

### DIFF
--- a/examples/nodejs/create-test.js
+++ b/examples/nodejs/create-test.js
@@ -20,6 +20,12 @@ const createTest = async () => {
       httpOnly: true
     }
   ]
+  const headers = [
+    {
+      name: 'User-Agent',
+      value: 'My Custom User Agent'
+    }
+  ]
 
   // Create the test
   const { uuid } = await Test.create({
@@ -27,7 +33,8 @@ const createTest = async () => {
     location,
     device,
     connection,
-    cookies
+    cookies,
+    headers
   })
 
   console.log(`Test created, ID: ${uuid}`)

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,8 +1,8 @@
 const { request } = require('./graphql')
 
 const CREATE_MUTATION = `
-  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!], $adBlockerIsEnabled: Boolean) {
-    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies, adBlockerIsEnabled: $adBlockerIsEnabled) {
+  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!], $headers: [HeaderInput!], $adBlockerIsEnabled: Boolean) {
+    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies, headers: $headers, adBlockerIsEnabled: $adBlockerIsEnabled) {
       uuid
     }
   }
@@ -94,6 +94,7 @@ const create = async ({
   device,
   connection,
   cookies,
+  headers,
   adblocker
 }) => {
   const response = await request({
@@ -103,6 +104,7 @@ const create = async ({
     device,
     connection,
     cookies,
+    headers,
     adBlockerIsEnabled: adblocker
   })
   return response.createTest

--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -30,9 +30,9 @@ const main = async function(args) {
   }
 
   if (args.headers) {
-    if (['{', '['].includes(args.headers.substr(0, 1))) {
+    try {
       headers = JSON.parse(args.headers)
-    } else {
+    } catch (e) {
       headers = fs.readFileSync(args.headers, 'utf-8')
       headers = JSON.parse(headers)
     }


### PR DESCRIPTION
- [x] Add headers to Node.JS API
- [x] Add --headers flag to CLI
- [x] Update Node.JS create-test example

The Node.JS API uses the existing HeaderInput format of `name` and `value`.

The CLI uses key/value pairs and accepts a string or a path to a file (ala lighthouse CLI).

### Example usage

```
calibre test create https://www.whatsmyua.info/ --headers="[{\"User-Agent\":\"My Inline Test Agent\"}]" --location=Sydney
```
Result: https://calibreapp.com/tests/4534ee8/f1abd1a

```
calibre test create https://www.whatsmyua.info/ --headers=./headers.json --location=Sydney
```
Result: https://calibreapp.com/tests/54c32da/c743f1b