### PR TITLE
TimeSeries: Return page and testProfile fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.3.2 - 2019-08-08
+
+- Update the TimeSeries api to return `uuid` and `canonical` for `pages` and `uuid`, `name`, `jsIsDisabled`, `adBlockIsEnabled`, `hasDeviceEmulation`, `hasBandwidthEmulation` and `isMobile` for `testProfiles`
+
 ### 2.3.1 - 2019-07-23
 
 - Set default count in `deploys` API

--- a/__tests__/cli/__snapshots__/index.test.js.snap
+++ b/__tests__/cli/__snapshots__/index.test.js.snap
@@ -26,4 +26,4 @@ Examples:
 For more information on Calibre, see http://localhost:5678."
 `;
 
-exports[`calibre --version 1`] = `"2.3.1"`;
+exports[`calibre --version 1`] = `"2.3.2"`;

--- a/examples/nodejs/time-series.js
+++ b/examples/nodejs/time-series.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/*
+  calibre v2.0.0+ required
+
+  This example will fetch time series data for a given site for the past 7 days
+  and group the data by test profile.
+*/
+
+const { TimeSeries } = require('calibre')
+
+const main = async () => {
+  const site = 'calibre'
+  const to = new Date()
+  const from = new Date()
+  const metrics = [
+    'lighthouse-performance-score',
+    'first-contentful-paint',
+    'consistently-interactive'
+  ]
+  from.setDate(to.getDate() - 7)
+
+  const timeSeries = await TimeSeries.list({
+    site,
+    from: from.toUTCString(),
+    to: to.toUTCString(),
+    measurements: metrics
+  })
+
+  const { pages, testProfiles, times, series, measurements } = timeSeries
+
+  const page = pages[0]
+  console.log(`Time series data for ${page.name} (${page.url})`)
+
+  testProfiles.forEach(testProfile => {
+    console.log('')
+    console.log(`${testProfile.name}`)
+
+    series
+      .filter(series => series.profile === testProfile.uuid)
+      .forEach(series => {
+        const measurement = measurements.find(
+          measurement => measurement.name === series.measurement
+        )
+        console.log(`  ${measurement.label}`)
+        times.forEach((time, index) => {
+          const value = series.values[index]
+          console.log(`    ${time.timestamp} - ${time.name} - ${value}`)
+        })
+      })
+  })
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "engines": {
     "node": "> 8.15.0"
   },

--- a/src/api/time-series.js
+++ b/src/api/time-series.js
@@ -24,11 +24,19 @@ const TIME_SERIES_QUERY = `
         }
 
         pages {
+          uuid
           name
+          canonical
         }
 
         testProfiles {
+          uuid
           name
+          jsIsDisabled
+          adBlockerIsEnabled
+          hasDeviceEmulation
+          hasBandwidthEmulation
+          isMobile
         }
 
         measurements {

--- a/src/api/time-series.js
+++ b/src/api/time-series.js
@@ -26,6 +26,7 @@ const TIME_SERIES_QUERY = `
         pages {
           uuid
           name
+          url
           canonical
         }
 


### PR DESCRIPTION
This PR will:

- Update the TimeSeries api to return `uuid` and `canonical` for `pages` and `uuid`, `name`, `jsIsDisabled`, `adBlockIsEnabled`, `hasDeviceEmulation`, `hasBandwidthEmulation` and `isMobile` for `testProfiles`
- Add Node.JS example for fetching time series data and grouping the output by test profile