### PR TITLE
Private tests

### DIFF
--- a/examples/nodejs/create-test.js
+++ b/examples/nodejs/create-test.js
@@ -10,6 +10,7 @@ const createTest = async () => {
   // Optional
   const device = 'iPhone8'
   const connection = 'good3G'
+  const isPrivate = false
   const cookies = [
     {
       name: 'app.uid',
@@ -34,7 +35,8 @@ const createTest = async () => {
     device,
     connection,
     cookies,
-    headers
+    headers,
+    isPrivate
   })
 
   console.log(`Test created, ID: ${uuid}`)

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,8 +1,8 @@
 const { request } = require('./graphql')
 
 const CREATE_MUTATION = `
-  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!], $headers: [HeaderInput!], $adBlockerIsEnabled: Boolean) {
-    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies, headers: $headers, adBlockerIsEnabled: $adBlockerIsEnabled) {
+  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!], $headers: [HeaderInput!], $adBlockerIsEnabled: Boolean, $isPrivate: Boolean) {
+    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies, headers: $headers, adBlockerIsEnabled: $adBlockerIsEnabled, isPrivate: $isPrivate) {
       uuid
     }
   }
@@ -16,6 +16,7 @@ const LIST_QUERY = `
         url
         formattedTestUrl
         adBlockerIsEnabled
+        isPrivate
 
         device {
           title
@@ -47,6 +48,7 @@ const GET_BY_UUID = `
         status
         updatedAt
         adBlockerIsEnabled
+        isPrivate
         runtimeError: artifact(name: TEST_ARTIFACT_RUNTIME_ERROR)
 
 
@@ -80,9 +82,9 @@ const GET_TEST_ARTIFACT_URLS = `
         uuid
 
         har: artifactURL(name: TEST_ARTIFACT_HAR)
-      	lighthouse: artifactURL(name: TEST_ARTIFACT_LIGHTHOUSE)
-      	image: mediaURL(name: TEST_MEDIA_IMAGE)
-      	video: mediaURL(name: TEST_MEDIA_VIDEO)
+        lighthouse: artifactURL(name: TEST_ARTIFACT_LIGHTHOUSE)
+        image: mediaURL(name: TEST_MEDIA_IMAGE)
+        video: mediaURL(name: TEST_MEDIA_VIDEO)
       }
     }
   }
@@ -95,7 +97,8 @@ const create = async ({
   connection,
   cookies,
   headers,
-  adblocker
+  adblocker,
+  private
 }) => {
   const response = await request({
     query: CREATE_MUTATION,
@@ -105,7 +108,8 @@ const create = async ({
     connection,
     cookies,
     headers,
-    adBlockerIsEnabled: adblocker
+    adBlockerIsEnabled: adblocker,
+    isPrivate: private
   })
   return response.createTest
 }

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -98,7 +98,7 @@ const create = async ({
   cookies,
   headers,
   adblocker,
-  private
+  isPrivate
 }) => {
   const response = await request({
     query: CREATE_MUTATION,
@@ -109,7 +109,7 @@ const create = async ({
     cookies,
     headers,
     adBlockerIsEnabled: adblocker,
-    isPrivate: private
+    isPrivate
   })
   return response.createTest
 }

--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -96,6 +96,11 @@ module.exports = {
         type: 'boolean',
         default: false
       })
+      .option('private', {
+        describe: 'Private tests are only accessible by logged in team members',
+        type: 'boolean',
+        default: false
+      })
       .option('cookie-jar', {
         describe: 'Uses a netscape formatted cookie jar file at this path'
       })

--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -46,8 +46,10 @@ const main = async function(args) {
     })
   }
 
+  const isPrivate = args.private
+
   try {
-    const { uuid } = await create({ ...args, cookies, headers })
+    const { uuid } = await create({ ...args, cookies, headers, isPrivate })
 
     if (!args.json) {
       spinner.succeed(`Test scheduled: ${uuid}`)


### PR DESCRIPTION
This PR adds support for private single pages tests.

- [x] Add `isPrivate` to GraphQL api
- [x] Add `--private` flag to `create test` command