### PR TITLE
Parse to/from args with parseISO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.0.2 - 2020-03-05
+
+- Fix parsing of `to` and `from` arguments in CLI `get-pulse-metrics` command.
+
 ### 3.0.1 - 2020-03-04
 
 - Allow use of token store for node

--- a/__tests__/cli/__snapshots__/index.test.js.snap
+++ b/__tests__/cli/__snapshots__/index.test.js.snap
@@ -27,4 +27,4 @@ Examples:
 For more information on Calibre, see http://localhost:5678."
 `;
 
-exports[`calibre --version 1`] = `"3.0.1"`;
+exports[`calibre --version 1`] = `"3.0.2"`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "engines": {
     "node": ">= 10.13.0"
   },

--- a/src/cli/site/get-pulse-metrics.js
+++ b/src/cli/site/get-pulse-metrics.js
@@ -1,6 +1,6 @@
 const ora = require('ora')
 const subDays = require('date-fns/subDays')
-const parse = require('date-fns/parse')
+const parseISO = require('date-fns/parseISO')
 
 const { humaniseError } = require('../../utils/api-error')
 const { list } = require('../../api/time-series')
@@ -20,8 +20,8 @@ const main = async args => {
     to = new Date()
     from = subDays(new Date(), 30)
   } else {
-    if (args.to) to = parse(args.to)
-    if (args.from) from = parse(args.from)
+    if (args.to) to = parseISO(args.to)
+    if (args.from) from = parseISO(args.from)
   }
 
   const variables = {


### PR DESCRIPTION
This PR fixes a bug where to/from args were not being parsed correctly, most likely since the upgrade of date-fns.

Date parsing is now done using parseISO