### PR TITLE
Update get pulse metrics description

### DIFF
--- a/src/cli/site/get-pulse-metrics.js
+++ b/src/cli/site/get-pulse-metrics.js
@@ -51,7 +51,7 @@ const main = async args => {
 
 module.exports = {
   command: 'get-pulse-metrics [options]',
-  describe: 'Get a recent timeline of metrics for a given page',
+  describe: 'Get timeseries metrics for a given site',
   builder: yargs => {
     yargs.options({
       site: options.site,


### PR DESCRIPTION
Given that the `--page` argument is now optional, it makes sense to update the command description so that people are able to find the right command to use more easily. 