### PR TITLE
Correction: Command and options are swapped

### DIFF
--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -6,7 +6,7 @@ const retrieveToken = () => {
   const token = process.env.CALIBRE_API_TOKEN || config.get('token')
   if (!token) {
     throw new Error(
-      'Please set your Calibre API token by running `calibre set token`\n or set the environment variable CALIBRE_API_TOKEN.\n\n See calibreapp.com/docs/api/tokens for help.'
+      'Please set your Calibre API token by running `calibre token set`\n or set the environment variable CALIBRE_API_TOKEN.\n\n See calibreapp.com/docs/api/tokens for help.'
     )
   }
 


### PR DESCRIPTION
The help message states to run `calibre set token`, but the command should really be `calibre token set`. 

In this PR: 

- [x] Update 'no token set' error message