### PR TITLE
Fix help log url display

### DIFF
--- a/__tests__/cli/__snapshots__/index.test.js.snap
+++ b/__tests__/cli/__snapshots__/index.test.js.snap
@@ -23,7 +23,7 @@ Examples:
   https://calibreapp.com --location=Sydney  Sydney emulating an iPhone 8 with a
   --device=iPhone8 --connection=good3G      3G connection
 
-For more information on Calibre, see http://localhost:5678."
+For more information on Calibre, see https://calibreapp.com"
 `;
 
 exports[`calibre --version 1`] = `"3.1.1"`;

--- a/src/cli.js
+++ b/src/cli.js
@@ -38,5 +38,5 @@ module.exports = require('yargs')
     process.exit(1)
   })
   .epilogue(
-    `For more information on Calibre, see ${process.env.CALIBRE_HOST}.`
+    `For more information on Calibre, see https://calibreapp.com`
   ).argv


### PR DESCRIPTION
Running `calibre --help` resulted in:
> `For more information on Calibre, see undefined.`

In this PR:

- [x] Adds the URL inline