### PR TITLE
Fix Create Test Profile: `javascript` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
   },
   "prettier": {
     "semi": false,
-    "singleQuote": true
+    "singleQuote": true,
+    "trailingComma": "none",
+    "arrowParens": "avoid"
   },
   "pkg": {
     "scripts": [

--- a/src/api/test-profile.js
+++ b/src/api/test-profile.js
@@ -107,7 +107,7 @@ const create = async ({
       device,
       connection,
       cookies,
-      jsIsDisabled: javascript,
+      jsIsDisabled: !javascript,
       adBlockerIsEnabled: adblocker
     }
   })
@@ -139,7 +139,7 @@ const update = async ({
       device,
       connection,
       cookies,
-      jsIsDisabled: javascript,
+      jsIsDisabled: !javascript,
       adBlockerIsEnabled: adblocker
     }
   })


### PR DESCRIPTION
The `javascript` flag should default to turning JavaScript on:
```
--javascript  Turn JavaScript execution on/off       [boolean] [default: true]
```

Currently, creating a new test profile disables javascript by default:
```
calibre site create-test-profile --site=calibre NewProfile
✔ Created Test Profile

⬢ NewProfile (xxx)
Created: 12:08PM 30-Sep-2020
Updated: 12:08PM 30-Sep-2020



• Javascript Disabled
```

And setting `javascript=true` disables JavaScript:

```
calibre site create-test-profile --site=calibre --javascript=true NewProfile
✔ Created Test Profile

⬢ NewProfile (78ab8d52-023a-4954-99fe-4b835af30b5e)
Created: 12:09PM 30-Sep-2020
Updated: 12:09PM 30-Sep-2020



• Javascript Disabled
```

This PR fixes this by passing the opposite of the `javascript` flag value to `jsIsDisabled` in the API. Therefore, a default profile will not have JavaScript disabled, and `javascript=true` will enable JavaScript and `javascript=false` will disable JavaScript.