### PR TITLE
TimeSeries: Return page with series data

### DIFF
--- a/src/api/time-series.js
+++ b/src/api/time-series.js
@@ -19,6 +19,7 @@ const TIME_SERIES_QUERY = `
         series {
           name
           profile
+          page
           measurement
           values
         }


### PR DESCRIPTION
This PR includes the `page` in the series response for TimeSeries so when you query multiple pages you can differentiate series by profiles and pages.

```json
{
  "times": […],
  "series": [
    {
      "name": "Profile Name",
      "profile": "profile uuid",
      "page": "page uuid",
      "measurement": "lighthouse-performance-score",
      "values": [ … ]
    },
  ],
  "pages": […]
  "testProfiles": […]
  "measurements": […]
  "csv": ""
}

```