### PR TITLE
Add `team` to Site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api/site.js
+++ b/src/api/site.js
@@ -6,6 +6,11 @@ const CREATE_MUTATION = `
       name
       slug
 
+      team {
+        name
+        slug
+      }
+
       agentSettings {
         location {
           identifier
@@ -41,6 +46,11 @@ const LIST_QUERY = `
         name
         slug
         createdAt
+
+        team {
+          name
+          slug
+        }
       }
     }
   }
@@ -58,6 +68,7 @@ const DELETE_MUTATION = `
 const create = async ({
   name,
   location,
+  team,
   pages,
   testProfiles,
   agentSettings
@@ -74,6 +85,7 @@ const create = async ({
     attributes: {
       name,
       pages,
+      team,
       testProfiles,
       agentSettings: updatedAgentSettings
     }

--- a/src/cli/site/create.js
+++ b/src/cli/site/create.js
@@ -36,6 +36,11 @@ const main = async function (args) {
       name: 'MotoG4, 3G connection',
       device: 'MotorolaMotoG4',
       connection: 'regular3G'
+    },
+    {
+      name: 'iPhone, 4G LTE',
+      device: 'iPhone8',
+      connection: 'LTE'
     }
   ]
 

--- a/src/cli/site/create.js
+++ b/src/cli/site/create.js
@@ -4,7 +4,7 @@ const { URL } = require('url')
 const { create } = require('../../api/site')
 const { humaniseError } = require('../../utils/api-error')
 
-const main = async function(args) {
+const main = async function (args) {
   let spinner
 
   if (!args.json) {
@@ -13,7 +13,7 @@ const main = async function(args) {
     spinner.start()
   }
 
-  const { name, location, url, schedule, interval } = args
+  const { name, location, url, team, schedule, interval } = args
   const pages = [
     {
       url,
@@ -40,7 +40,13 @@ const main = async function(args) {
   ]
 
   try {
-    const site = await create({ name, pages, agentSettings, testProfiles })
+    const site = await create({
+      name,
+      team,
+      pages,
+      agentSettings,
+      testProfiles
+    })
 
     if (!args.json) {
       spinner.succeed(`${site.name} added to Calibre`)
@@ -64,6 +70,9 @@ module.exports = {
       })
       .option('location', {
         describe: 'Calibre will monitor from this location'
+      })
+      .option('team', {
+        describe: 'The identifying slug of the team'
       })
       .option('schedule', {
         describe:


### PR DESCRIPTION
This PR adds the ability to set the `team` when creating a Site via the Node.JS API and CLI.