### PR TITLE
Metrics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,19 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm link
-    - run: npm run ci
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm link
+      - run: npm run ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 4.0.0 - 2021-08-17
+
+**Breaking Changes**
+
+- Replace `site get-pulse-metrics` with `site metrics`
+- Add `metric-list`
+- Drop support for Node 10.x
+
 ### 3.3.0 - 2021-08-04
 
 - Add `team` input to create site

--- a/__tests__/cli/__snapshots__/index.test.js.snap
+++ b/__tests__/cli/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ Commands:
                            connection options
   calibre device-list      Print a list of Calibre’s test devices
   calibre location-list    Print a list of Calibre’s test locations
+  calibre metric-list      Print a list of Calibre’s metrics
   calibre request          Make a request to the Calibre GraphQL API
   calibre site <command>   Tasks related to sites
   calibre test <command>   Single page tests
@@ -26,5 +27,3 @@ Examples:
 
 For more information on Calibre, see https://calibreapp.com"
 `;
-
-exports[`calibre --version 1`] = `"3.3.0"`;

--- a/__tests__/cli/index.test.js
+++ b/__tests__/cli/index.test.js
@@ -4,8 +4,3 @@ test('calibre --help', async () => {
   const { stdout } = await execa('calibre', ['--help'])
   expect(stdout).toMatchSnapshot()
 })
-
-test('calibre --version', async () => {
-  const { stdout } = await execa('calibre', ['--version'])
-  expect(stdout).toMatchSnapshot()
-})

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -1,6 +1,6 @@
 ## Requirements to run these examples
 
-- Node 10.13+
+- Node 12.22+
 - Install the dependencies by running `npm install` from within the `examples/nodejs` directory.
 - [A Calibre API token](https://calibreapp.com/docs/api/tokens)
 

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "calibre-nodejs-examples",
   "version": "1.0.1",
   "engines": {
-    "node": ">= 10.13.0"
+    "node": ">= 12.22.4"
   },
   "description": "Calibre’s Node.JS examples",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1931,9 +1931,9 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -8416,9 +8416,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -8426,9 +8426,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -8455,9 +8455,9 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -8475,9 +8475,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "calibre",
   "version": "3.3.0",
   "engines": {
-    "node": ">= 10.13.0"
+    "node": ">= 12.22.4"
   },
   "description": "Calibre - Page speed performance testing with Google Lighthouse",
   "author": "calibreapp.com",
@@ -24,7 +24,7 @@
     "ora": "^5.1.0",
     "stats-percentile": "^3.1.0",
     "update-notifier": "^5.0.0",
-    "yargs": "^16.0.3"
+    "yargs": "^17.1.1"
   },
   "devDependencies": {
     "eslint": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "engines": {
     "node": ">= 12.22.4"
   },

--- a/src/api/metric.js
+++ b/src/api/metric.js
@@ -1,0 +1,33 @@
+const { request } = require('./graphql')
+
+const LIST_QUERY = `
+  query {
+    metrics {
+      __typename
+      name
+      value
+      label
+      shortLabel
+      budgetThreshold
+      formatter
+      docsPath
+      goodStop
+      poorStop
+      recommended
+      category {
+        name
+        label
+        value
+      }
+    }
+  }
+`
+
+const list = async () => {
+  const response = await request({ query: LIST_QUERY })
+  return response.metrics
+}
+
+module.exports = {
+  list
+}

--- a/src/api/time-series.js
+++ b/src/api/time-series.js
@@ -10,46 +10,48 @@ const TIME_SERIES_QUERY = `
     $to: String
   ) {
     organisation {
-      timeSeries(site: $site, from: $from, to: $to, measurements: $measurements, pages: $pages, profiles: $profiles) {
-        times {
-          name
-          snapshot
-          timestamp
-        }
+      site(slug: $site) {
+        timeSeries(from: $from, to: $to, measurements: $measurements, pages: $pages, profiles: $profiles) {
+          times {
+            name
+            snapshot
+            timestamp
+          }
 
-        series {
-          name
-          profile
-          page
-          measurement
-          values
-        }
+          series {
+            name
+            profile
+            page
+            measurement
+            values
+          }
 
-        pages {
-          uuid
-          name
-          url
-          canonical
-        }
+          pages {
+            uuid
+            name
+            url
+            canonical
+          }
 
-        testProfiles {
-          uuid
-          name
-          jsIsDisabled
-          adBlockerIsEnabled
-          hasDeviceEmulation
-          hasBandwidthEmulation
-          isMobile
-        }
+          testProfiles {
+            uuid
+            name
+            jsIsDisabled
+            adBlockerIsEnabled
+            hasDeviceEmulation
+            hasBandwidthEmulation
+            isMobile
+          }
 
-        measurements {
-          name
-          label
-          formatter
-          docsPath
-        }
+          measurements {
+            name
+            label
+            formatter
+            docsPath
+          }
 
-        csv
+          csv
+        }
       }
     }
   }
@@ -72,7 +74,7 @@ const list = async ({
     from,
     to
   })
-  return response.organisation.timeSeries
+  return response.organisation.site.timeSeries
 }
 
 module.exports = {

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,8 @@ module.exports = require('yargs')
   .usage(`${chalk.bold('♤  calibre')} subcommand [options]`)
   .commandDir('./cli')
   .demandCommand()
+  .recommendCommands()
+  .strict()
   .help('help')
   .updateStrings({
     'Commands:': chalk.grey('Commands:\n'),

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,7 +11,7 @@ module.exports = require('yargs')
   .commandDir('./cli')
   .demandCommand()
   .recommendCommands()
-  .strict()
+  .strictCommands()
   .help('help')
   .updateStrings({
     'Commands:': chalk.grey('Commands:\n'),

--- a/src/cli/metric-list.js
+++ b/src/cli/metric-list.js
@@ -1,0 +1,69 @@
+const chalk = require('chalk')
+const ora = require('ora')
+const columnify = require('columnify')
+const logSymbols = require('log-symbols')
+
+const { list } = require('../api/metric')
+const { humaniseError } = require('../utils/api-error')
+const { options } = require('../utils/cli')
+const { format } = require('../utils/formatters')
+
+const main = async args => {
+  let index
+  let spinner
+  if (!args.json) {
+    spinner = ora('Connecting to Calibre')
+    spinner.color = 'magenta'
+    spinner.start()
+  }
+
+  try {
+    index = await list(args)
+    if (args.json) return console.log(JSON.stringify(index, null, 2))
+  } catch (e) {
+    if (args.json) return console.error(e)
+    spinner.fail()
+    throw new Error(humaniseError(e))
+  }
+
+  spinner.stop()
+  console.log(`${chalk.bold(index.length)} metrics`)
+
+  const rows = index.map(row => {
+    return {
+      identifier: chalk.cyan(row.value),
+      name: row.label,
+      category: row.category.label,
+      good: `${row.budgetThreshold === 'GreaterThan' ? '<' : '>'} ${format({
+        formatter: row.formatter,
+        value: row.goodStop
+      })}`,
+      poor: `${row.budgetThreshold === 'GreaterThan' ? '>' : '<'} ${format({
+        formatter: row.formatter,
+        value: row.poorStop
+      })}`,
+      recommended: row.recommended
+        ? chalk.bold.green(`${logSymbols.success}`)
+        : null
+    }
+  })
+
+  console.log(
+    columnify(rows, {
+      columnSplitter: ' | ',
+      truncate: true,
+      maxLineWidth: 'auto'
+    })
+  )
+}
+
+module.exports = {
+  command: 'metric-list',
+  describe: 'Print a list of Calibre’s metrics',
+  handler: main,
+  builder: yargs => {
+    yargs.options({
+      json: options.json
+    })
+  }
+}

--- a/src/cli/site/get-pulse-metrics.js
+++ b/src/cli/site/get-pulse-metrics.js
@@ -1,77 +1,12 @@
-const ora = require('ora')
-const subDays = require('date-fns/subDays')
-const parseISO = require('date-fns/parseISO')
-
-const { humaniseError } = require('../../utils/api-error')
-const { list } = require('../../api/time-series')
-const formatPulseTimeline = require('../../views/pulse-timeline')
-const { options } = require('../../utils/cli')
-
-const main = async args => {
-  let spinner
-  if (!args.json && !args.csv) {
-    spinner = ora('Connecting to Calibre')
-    spinner.color = 'magenta'
-    spinner.start()
-  }
-
-  let to, from
-  if (args['30-day']) {
-    to = new Date()
-    from = subDays(new Date(), 30)
-  } else {
-    if (args.to) to = parseISO(args.to)
-    if (args.from) from = parseISO(args.from)
-  }
-
-  const variables = {
-    site: args.site,
-    pages: [args.page],
-    measurements: args.metrics,
-    from,
-    to
-  }
-
-  try {
-    const { csv, ...timeSeries } = await list(variables)
-
-    if (args.csv) return console.log(csv)
-    if (args.json) return console.log(JSON.stringify(timeSeries, null, 2))
-
-    spinner.stop()
-    console.log(formatPulseTimeline(timeSeries))
-  } catch (e) {
-    if (args.json) return console.error(e)
-    if (args.csv) return console.error('Error', e)
-
-    spinner.fail(humaniseError(e))
-    throw new Error(humaniseError(e))
-  }
+const main = async () => {
+  throw new Error(
+    'get-pulse-metrics has been deprecated. Please use `calibre site metrics` instead.'
+  )
 }
 
 module.exports = {
   command: 'get-pulse-metrics [options]',
-  describe: 'Get timeseries metrics for a given site',
-  builder: yargs => {
-    yargs.options({
-      site: options.site,
-      page: {
-        describe: 'The identifying uuid of a page'
-      },
-      metrics: {
-        type: 'array',
-        describe:
-          'A list of metrics to return. eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
-      },
-      json: options.json,
-      csv: options.csv,
-      from: options.from,
-      to: options.to,
-      '30-day': {
-        describe:
-          'Get the last 30 days of metrics (without this flag, the to and from values will be used)'
-      }
-    })
-  },
+  describe: 'Deprecated in favour of the `metrics` command.',
+  deprecated: true,
   handler: main
 }

--- a/src/cli/site/metrics.js
+++ b/src/cli/site/metrics.js
@@ -1,0 +1,72 @@
+const ora = require('ora')
+const subDays = require('date-fns/subDays')
+const parseISO = require('date-fns/parseISO')
+
+const { humaniseError } = require('../../utils/api-error')
+const { list } = require('../../api/time-series')
+const formatPulseTimeline = require('../../views/pulse-timeline')
+const { options } = require('../../utils/cli')
+
+const main = async args => {
+  let spinner
+  if (!args.json && !args.csv) {
+    spinner = ora('Connecting to Calibre')
+    spinner.color = 'magenta'
+    spinner.start()
+  }
+
+  let to, from
+  if (args['30-day']) {
+    to = new Date()
+    from = subDays(new Date(), 30)
+  } else {
+    if (args.to) to = parseISO(args.to)
+    if (args.from) from = parseISO(args.from)
+  }
+
+  const variables = {
+    site: args.site,
+    pages: args.pages,
+    measurements: args.metrics,
+    from,
+    to
+  }
+
+  try {
+    const { csv, ...timeSeries } = await list(variables)
+
+    if (args.csv) return console.log(csv)
+    if (args.json) return console.log(JSON.stringify(timeSeries, null, 2))
+
+    spinner.stop()
+    console.log(formatPulseTimeline(timeSeries))
+  } catch (e) {
+    if (args.json) return console.error(e)
+    if (args.csv) return console.error('Error', e)
+
+    spinner.fail(humaniseError(e))
+    throw new Error(humaniseError(e))
+  }
+}
+
+module.exports = {
+  command: 'metrics [options]',
+  describe: 'Get timeseries metrics for a given site',
+  builder: yargs => {
+    yargs.options({
+      site: options.site,
+      pages: options.pages,
+      profiles: options.profiles,
+      metrics: options.metrics,
+      json: options.json,
+      csv: options.csv,
+      from: options.from,
+      to: options.to,
+      '30-day': {
+        describe:
+          'Get the last 30 days of metrics (without this flag, the to and from values will be used)'
+      }
+    })
+  },
+  handler: main
+}

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -21,6 +21,19 @@ const options = {
   },
   cursor: {
     describe: 'The cursor to fetch records after'
+  },
+  pages: {
+    describe:
+      'A list of page uuids to return metrics for. eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page'
+  },
+  profiles: {
+    describe:
+      'A list of profile uuids to return metrics for. eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile'
+  },
+  metrics: {
+    type: 'array',
+    describe:
+      'A list of metrics to return. eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
   }
 }
 

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -24,16 +24,16 @@ const options = {
   },
   pages: {
     describe:
-      'A list of page uuids to return metrics for. eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page'
+      'A space separated list of page uuids to return metrics for. eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page'
   },
   profiles: {
     describe:
-      'A list of profile uuids to return metrics for. eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile'
+      'A space separated list of profile uuids to return metrics for. eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile'
   },
   metrics: {
     type: 'array',
     describe:
-      'A list of metrics to return. eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
+      'A space separated list of metrics to return. eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
   }
 }
 

--- a/src/views/pulse-timeline.js
+++ b/src/views/pulse-timeline.js
@@ -47,7 +47,11 @@ ${set.name}
 
     return `
 ${chalk.blue.bold(measurement.label)}
-${metrics.join('\n')}
+${
+  metrics.length
+    ? metrics.join('\n')
+    : '\nThere is no data for this time period'
+}
 `
   })
 


### PR DESCRIPTION
**Breaking Changes: Will require major version bump**

This PR will:

- Add `site metrics` command which will return metrics for all pages by default
- Deprecate the `site get-pulse-metrics` command in favour of `site metrics`
- Add `metric-list` command to return a list of all available metrics
- Show help when no command is found (by using `strictCommand`)