### PR TITLE
Fix `profiles` parameter not being passed for site metrics, update CLI option descriptions

### DIFF
--- a/src/cli/site/metrics.js
+++ b/src/cli/site/metrics.js
@@ -28,6 +28,7 @@ const main = async args => {
     site: args.site,
     pages: args.pages,
     measurements: args.metrics,
+    profiles: args.profiles,
     from,
     to
   }

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -23,17 +23,19 @@ const options = {
     describe: 'The cursor to fetch records after'
   },
   pages: {
+    type: 'array',
     describe:
-      'A space separated list of page uuids to return metrics for. eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page'
+      'A space separated list of page uuids to return metrics for (when not set, defaults to all pages). eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page'
   },
   profiles: {
+    type: 'array',
     describe:
-      'A space separated list of profile uuids to return metrics for. eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile'
+      'A space separated list of profile uuids to return metrics for (when not set, defaults to all test profiles). eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile'
   },
   metrics: {
     type: 'array',
     describe:
-      'A space separated list of metrics to return. eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
+      'A space separated list of metrics to return (when not set, defaults to all metrics). eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
   }
 }
 


### PR DESCRIPTION
Currently the `--help` output says that you can provide `--profiles` arguments to the CLI to filter the metrics to the desired Test Profiles, however that argument is not respected as it does not get passed to the GraphQL query.

This change simply passes the `profiles` command line argument through to the TimeSeries `list` call which already supports it. 

Additionally updated the CLI `options` descriptions to mark `pages` and `profiles` as array types since they accept multiple values.
Also added text to the descriptions of `pages`, `profiles` and `metrics` describing default behaviour when not set in the same form as the `from` and `to` options.