### PR TITLE
Fix snapshot downloads when profile or page names include path separator

### DIFF
--- a/src/cli/site/download-snapshot-artifacts.js
+++ b/src/cli/site/download-snapshot-artifacts.js
@@ -53,11 +53,11 @@ const main = async args => {
     for (const test of response.snapshot.tests) {
       const { page, testProfile: profile } = test
       const pageDirectory = mkdirp(
-        directories.concat([`${page.name}-${page.uuid}`])
+        directories.concat([`${page.name.replace(path.sep, '')}-${page.uuid}`])
       )
 
       const profileDirectory = mkdirp(
-        [pageDirectory].concat([`${profile.name}-${profile.uuid}`])
+        [pageDirectory].concat([`${profile.name.replace(path.sep, '')}-${profile.uuid}`])
       )
       const testManifest = {
         page: {


### PR DESCRIPTION
When the path separator appears in a profile or page name, such as a page named "Article w/ featured image," `mkdirp` will fail to create the directory, blocking snapshot downloads.