### PR TITLE
Update command descriptions (CAL-397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 5.01 (2022-05-13)
+## 🚩 Commands and flags
+* Adds a new command: `calibre team list` to list all Teams depending on API Token in use.
+
+## 🛠 Core
+* Updates all command and flag descriptions for clarity and accuracy.
+
+## 📖 Documentation
+* updates `README.md` to include link to Calibre’s documentation page for all CLI commands
+
 # 5.0.0 (2022-04-29)
 
 ## 💥 Breaking changes

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -235,6 +235,15 @@ Flags:
   * `--json`: Outputs the results of the command in JSON format.
 
 
+### calibre team list
+
+List Teams based on API Token access. For Admin Tokens, this will list all teams or as specified based on your settings. For Personal Access Tokens, this will list Teams that you have access to.
+
+Flags:
+ 
+  * `--json`: Outputs the results of the command in JSON format.
+
+
 ### calibre test create <url> [options]
 
 Run a Single Page Test against any public URL.

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -1,21 +1,21 @@
 
 ### calibre site create <name> [options]
 
-Add a site for Calibre to monitor
+Add a Site for Calibre to monitor.
 
 Flags:
  
-  * `--url`: The homepage URL of the site,
-  * `--location`: Calibre will monitor from this location,
-  * `--team`: The identifying slug of the team,
-  * `--schedule`: Schedule for automated snapshots. One of: hourly, daily, every_x_hours (default: `every_x_hours`),
-  * `--interval`: Automated snapshot interval. UTC hour of day for 'daily', hour interval for 'every_x_hours' (default: `6`),
+  * `--url`: The URL of the Site.,
+  * `--location`: Choose the location for the test.,
+  * `--team`: The identifying slug of the Team.,
+  * `--schedule`: Set the schedule for automated Snapshots. Available options: hourly, daily, every_x_hours. (default: `every_x_hours`),
+  * `--interval`: Set the Snapshot interval. Provide UTC hour (between 0 and 23) for daily Snapshots and numeric hour interval for every_x_hours option (between 1 and 168 hours). (default: `6`),
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site list
 
-Print a list of sites being tracked by Calibre
+List all Sites you are tracking in Calibre.
 
 Flags:
  
@@ -24,30 +24,30 @@ Flags:
 
 ### calibre site download-snapshot-artifacts [options]
 
-Downloads the artifacts of a snapshot to ./snapshot-artifacts/<id>
+Download the artifacts of a Snapshot to ./snapshot-artifacts/<id>. Includes: lighthouse.json, render progress screenshots, render progress MP4 video, HAR file (request log) and all other metrics and data available through the Calibre interface.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--id`: The id of the snapshot,
+  * `--id`: The id of the Snapshot.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site get-snapshot-metrics [options]
 
-Get the metrics of a given snapshot
+Get all metrics of a given Snapshot.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--snapshot`: The identifying id of a snapshot,
+  * `--snapshot`: The id of a Snapshot.,
   * `--json`: Outputs the results of the command in JSON format.,
   * `--csv`: Outputs the results of the command in CSV format.
 
 
 ### calibre site metrics [options]
 
-Get timeseries metrics for a given site
+Get time-series metrics for a selected Site.
 
 Flags:
  
@@ -59,12 +59,12 @@ Flags:
   * `--csv`: Outputs the results of the command in CSV format.,
   * `--from`: The start date to retrieve data from in the Year-Month-Day format (default: 7 days ago).,
   * `--to`: The end date to retrieve data from in the Year-Month-Day format (default: today).,
-  * `--30-day`: Get the last 30 days of metrics (without this flag, the to and from values will be used)
+  * `--30-day`: Get the last 30 days of metrics. Without this flag, CLI will use the to and from values.
 
 
 ### calibre site deploys [options]
 
-Print a list of deploys
+List all deployments for a Site.
 
 Flags:
  
@@ -76,32 +76,32 @@ Flags:
 
 ### calibre site create-deploy [options]
 
-Create a deploy
+Create a deployment.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--revision`: The source control revision id of the code you are deploying (e.g. git hash or tag name),
-  * `--repository`: The base URL of the repository containing the source code being deployed (e.g. https://github.com/calibreapp/app),
-  * `--username`: The name of the user who deployed the code,
+  * `--revision`: The source control revision id of the code you are deploying. It could be a git hash or a tag name.,
+  * `--repository`: The base URL of the repository containing the source code being deployed (e.g. https://github.com/calibreapp/app).,
+  * `--username`: The username of who deployed the code.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site delete-deploy [options]
 
-Deletes a deploy from a site
+Delete a deploy from a selected Site.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--uuid`: The uuid of the deploy,
-  * `--confirm`: Confirm the deletion,
+  * `--uuid`: The UUID of the deploy.,
+  * `--confirm`: Use this flag to confirm the deletion of the selected deploy.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site pages [options]
 
-Print a list of pages for a given site
+List Pages for a selected Site.
 
 Flags:
  
@@ -113,43 +113,43 @@ Flags:
 
 ### calibre site create-page <name> [options]
 
-Add a page to an existing site tracked by Calibre
+Add a Page to an existing Site tracked by Calibre.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--url`: The name of the page,
+  * `--url`: The name of the Page.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site update-page [options]
 
-Update the name and/or URL of a page
+Update the name or URL of a Page.
 
 Flags:
  
-  * `--uuid`: The UUID of the page,
-  * `--name`: The name of the page,
-  * `--url`: The URL of the page,
+  * `--uuid`: The UUID of the Page.,
+  * `--name`: Update the name of the Page.,
+  * `--url`: Update the URL of the Page.,
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site delete-page [options]
 
-Deletes a page from a site
+Delete a Page from a selected Site.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--uuid`: The UUID of the page,
-  * `--confirm`: Confirm the deletion,
+  * `--uuid`: The UUID of the Page.,
+  * `--confirm`: Use this flag to confirm the deletion of the selected Page.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site snapshots [options]
 
-Print a list of snapshots
+List selected Snapshots for a Site.
 
 Flags:
  
@@ -161,30 +161,30 @@ Flags:
 
 ### calibre site create-snapshot [options]
 
-Create a snapshot
+Create a Snapshot.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--ref`: Sets a reference to the snapshot,
+  * `--ref`: Set a reference to the Snapshot.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site delete-snapshot [options]
 
-Deletes a snapshot from a site
+Delete a Snapshot from a selected Site.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--id`: The id of the snapshot,
-  * `--confirm`: Confirm the deletion,
+  * `--id`: The id of the Snapshot.,
+  * `--confirm`: Use this flag to confirm the deletion of the selected Snapshot.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site test-profiles [options]
 
-Print a list of test profiles for a given site
+List all Test Profiles for a Site.
 
 Flags:
  
@@ -194,67 +194,67 @@ Flags:
 
 ### calibre site create-test-profile <name> [options]
 
-Add a test profile to a site
+Add a Test Profile to a Site.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--device`: Sets the emulated device that the profile will be run on,
-  * `--connection`: Sets the emulated connection speed this profile,
-  * `--javascript`: Turn JavaScript execution on/off (default: `true`) (boolean),
-  * `--adblocker`: Turn adblocking on/off (boolean),
-  * `--cookie-jar`: Uses a netscape formatted cookie jar file at this path,
+  * `--device`: Choose the emulated test device.,
+  * `--connection`: Choose the emulated network connection speed.,
+  * `--javascript`: Turn JavaScript execution on or off. (default: `true`) (boolean),
+  * `--adblocker`: Turn adblocking on or off. (boolean),
+  * `--cookie-jar`: Set cookies by specifying a path to a Netscape formatted cookie jar file.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site update-test-profile [options]
 
-Update a test profile. Only updates attributes sent.
+Update Test Profile settings. Only changes specified attributes.
 
 Flags:
  
-  * `--uuid`: The UUID of the test profile,
-  * `--device`: Sets the emulated device that the profile will be run on,
-  * `--connection`: Sets the emulated connection speed this profile,
+  * `--uuid`: The UUID of the Test Profile.,
+  * `--device`: Set the emulated device.,
+  * `--connection`: Set the emulated network connection speed.,
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
   * `--json`: Outputs the results of the command in JSON format.,
-  * `--javascript`: Turn JavaScript execution on/off (default: `true`) (boolean),
-  * `--adblocker`: Turn adblocking on/off (boolean),
-  * `--cookie-jar`: Uses a netscape formatted cookie jar file at this path
+  * `--javascript`: Turn JavaScript execution on or off (default: `true`) (boolean),
+  * `--adblocker`: Turn adblocking on or off. (boolean),
+  * `--cookie-jar`: Set cookies by specifying a path to a Netscape formatted cookie jar file.
 
 
 ### calibre site delete-test-profile [options]
 
-Deletes a test profile from a site
+Delete a Test Profile from a Site.
 
 Flags:
  
   * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
-  * `--uuid`: The UUID of the test profile,
-  * `--confirm`: Confirm the deletion,
+  * `--uuid`: The UUID of the Test Profile.,
+  * `--confirm`: Use this flag to confirm the deletion of the selected Test Profile.,
   * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre test create <url> [options]
 
-Run a test against any public URL
+Run a Single Page Test against any public URL.
 
 Flags:
  
-  * `--device`: Sets the emulated device that the test will be run on,
-  * `--location`: The test will be run on a machine in this location,
-  * `--connection`: Sets the emulated connection speed for this test,
-  * `--adblocker`: Turn adblocking on/off (boolean),
-  * `--private`: Private tests are only accessible by logged in team members (boolean),
-  * `--cookie-jar`: Uses a netscape formatted cookie jar file at this path,
-  * `--headers`: Stringify'd JSON HTTP Header key/value pairs or path to JSON file of HTTP Header key/value pairs ,
+  * `--device`: Choose the emulated test device.,
+  * `--location`: Choose the location for the test.,
+  * `--connection`: Choose the emulated network connection speed.,
+  * `--adblocker`: Turn adblocking on or off. (boolean),
+  * `--private`: Make the results of a test private (only accessible by members of your Calibre organisation). (boolean),
+  * `--cookie-jar`: Set cookies by specifying a path to a Netscape formatted cookie jar file.,
+  * `--headers`: Set HTTP headers by providing a path to a JSON file or a valid JSON key-value pairs.,
   * `--json`: Outputs the results of the command in JSON format.,
-  * `--waitForTest`: Wait for test to complete before returning (boolean)
+  * `--waitForTest`: Wait for the test to complete before showing the results (default: test result link is shown immediately). (boolean)
 
 
 ### calibre test download-artifacts <uuid>
 
-Downloads the artifacts of a test to ./test-artifacts/<uuid>
+Download the artifacts of a test to ./test-artifacts/<uuid>. Includes: lighthouse.json, render progress screenshots, render progress MP4 video, HAR file (request log) and all other metrics and data available through the Calibre interface.
 
 Flags:
  
@@ -263,7 +263,7 @@ Flags:
 
 ### calibre test list
 
-Print a list of previously run tests
+List all previously run Single Page Tests (includes UUID, URL, device, connection, test location and status).
 
 Flags:
  
@@ -272,7 +272,7 @@ Flags:
 
 ### calibre test show <uuid>
 
-Print the details of a given test
+See the results of a Single Page Test (also as outputted by the test create command).
 
 Flags:
  

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -3,338 +3,334 @@
 
 Add a site for Calibre to monitor
 
-Options:
+Flags:
  
-  * `url`: The homepage URL of the site,
-  * `location`: Calibre will monitor from this location,
-  * `team`: The identifying slug of the team,
-  * `schedule`: Schedule for automated snapshots. One of: hourly, daily, every_x_hours (default: `every_x_hours`),
-  * `interval`: Automated snapshot interval. UTC hour of day for 'daily', hour interval for 'every_x_hours' (default: `6`),
-  * `json`: Output in JSON format
+  * `--url`: The homepage URL of the site,
+  * `--location`: Calibre will monitor from this location,
+  * `--team`: The identifying slug of the team,
+  * `--schedule`: Schedule for automated snapshots. One of: hourly, daily, every_x_hours (default: `every_x_hours`),
+  * `--interval`: Automated snapshot interval. UTC hour of day for 'daily', hour interval for 'every_x_hours' (default: `6`),
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site list
 
 Print a list of sites being tracked by Calibre
 
-Options:
+Flags:
  
-  * `json`: Output in JSON format
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site download-snapshot-artifacts [options]
 
 Downloads the artifacts of a snapshot to ./snapshot-artifacts/<id>
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `id`: The id of the snapshot,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--id`: The id of the snapshot,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site get-snapshot-metrics [options]
 
 Get the metrics of a given snapshot
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `snapshot`: The identifying id of a snapshot,
-  * `json`: Output in JSON format,
-  * `csv`: Output in CSV format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--snapshot`: The identifying id of a snapshot,
+  * `--json`: Outputs the results of the command in JSON format.,
+  * `--csv`: Outputs the results of the command in CSV format.
 
 
 ### calibre site metrics [options]
 
 Get timeseries metrics for a given site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `pages`: A space separated list of page uuids to return metrics for (when not set, defaults to all pages). eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page (array),
-  * `profiles`: A space separated list of profile uuids to return metrics for (when not set, defaults to all test profiles). eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile (array),
-  * `metrics`: A space separated list of metrics to return (when not set, defaults to all metrics). eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric (array),
-  * `json`: Output in JSON format,
-  * `csv`: Output in CSV format,
-  * `from`: The start date to retrieve from in the format Year-Month-Day (when not set, defaults to 7 days ago),
-  * `to`: The end date to retrieve to in the format Year-Month-Day (when not set, defaults to today),
-  * `30-day`: Get the last 30 days of metrics (without this flag, the to and from values will be used)
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--pages`: A list of Page UUIDs to return metrics for. You can separate multiple Pages by a space or use multiple --pages flags. (array),
+  * `--profiles`: A list of Test Profile UUIDs to return metrics for. You can separate multiple Test Profiles by a space or use multiple --profiles flags. (array),
+  * `--metrics`: A list of metric UUIDs to return metrics for. You can separate multiple metrics by a space or use multiple --metrics flags. (array),
+  * `--json`: Outputs the results of the command in JSON format.,
+  * `--csv`: Outputs the results of the command in CSV format.,
+  * `--from`: The start date to retrieve data from in the Year-Month-Day format (default: 7 days ago).,
+  * `--to`: The end date to retrieve data from in the Year-Month-Day format (default: today).,
+  * `--30-day`: Get the last 30 days of metrics (without this flag, the to and from values will be used)
 
 
 ### calibre site deploys [options]
 
 Print a list of deploys
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `count`: The number of records to return, maximum: 500 (default: `25`),
-  * `cursor`: The cursor to fetch records after,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--count`: The number of items to return (default: 25, maximum: 500). (default: `25`),
+  * `--cursor`: The cursor to fetch records after,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site create-deploy [options]
 
 Create a deploy
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `revision`: The source control revision id of the code you are deploying (e.g. git hash or tag name),
-  * `repository`: The base URL of the repository containing the source code being deployed (e.g. https://github.com/calibreapp/app),
-  * `username`: The name of the user who deployed the code,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--revision`: The source control revision id of the code you are deploying (e.g. git hash or tag name),
+  * `--repository`: The base URL of the repository containing the source code being deployed (e.g. https://github.com/calibreapp/app),
+  * `--username`: The name of the user who deployed the code,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site delete-deploy [options]
 
 Deletes a deploy from a site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `uuid`: The uuid of the deploy,
-  * `confirm`: Confirm the deletion,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--uuid`: The uuid of the deploy,
+  * `--confirm`: Confirm the deletion,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site pages [options]
 
 Print a list of pages for a given site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `count`: The number of records to return, maximum: 500 (default: `25`),
-  * `cursor`: The cursor to fetch records after,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--count`: The number of items to return (default: 25, maximum: 500). (default: `25`),
+  * `--cursor`: The cursor to fetch records after,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site create-page <name> [options]
 
 Add a page to an existing site tracked by Calibre
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `url`: The name of the page,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--url`: The name of the page,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site update-page [options]
 
 Update the name and/or URL of a page
 
-Options:
+Flags:
  
-  * `uuid`: The UUID of the page,
-  * `name`: The name of the page,
-  * `url`: The URL of the page,
-  * `site`: The identifying slug of a site (string),
-  * `json`: Output in JSON format
+  * `--uuid`: The UUID of the page,
+  * `--name`: The name of the page,
+  * `--url`: The URL of the page,
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site delete-page [options]
 
 Deletes a page from a site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `uuid`: The UUID of the page,
-  * `confirm`: Confirm the deletion,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--uuid`: The UUID of the page,
+  * `--confirm`: Confirm the deletion,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site snapshots [options]
 
 Print a list of snapshots
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `count`: The number of records to return, maximum: 500 (default: `25`),
-  * `cursor`: The cursor to fetch records after,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--count`: The number of items to return (default: 25, maximum: 500). (default: `25`),
+  * `--cursor`: The cursor to fetch records after,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site create-snapshot [options]
 
 Create a snapshot
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `ref`: Sets a reference to the snapshot,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--ref`: Sets a reference to the snapshot,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site delete-snapshot [options]
 
 Deletes a snapshot from a site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `id`: The id of the snapshot,
-  * `confirm`: Confirm the deletion,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--id`: The id of the snapshot,
+  * `--confirm`: Confirm the deletion,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site test-profiles [options]
 
 Print a list of test profiles for a given site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site create-test-profile <name> [options]
 
 Add a test profile to a site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `device`: Sets the emulated device that the profile will be run on,
-  * `connection`: Sets the emulated connection speed this profile,
-  * `javascript`: Turn JavaScript execution on/off (default: `true`) (boolean),
-  * `adblocker`: Turn adblocking on/off (boolean),
-  * `cookie-jar`: Uses a netscape formatted cookie jar file at this path,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--device`: Sets the emulated device that the profile will be run on,
+  * `--connection`: Sets the emulated connection speed this profile,
+  * `--javascript`: Turn JavaScript execution on/off (default: `true`) (boolean),
+  * `--adblocker`: Turn adblocking on/off (boolean),
+  * `--cookie-jar`: Uses a netscape formatted cookie jar file at this path,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre site update-test-profile [options]
 
 Update a test profile. Only updates attributes sent.
 
-Options:
+Flags:
  
-  * `uuid`: The UUID of the test profile,
-  * `device`: Sets the emulated device that the profile will be run on,
-  * `connection`: Sets the emulated connection speed this profile,
-  * `site`: The identifying slug of a site (string),
-  * `json`: Output in JSON format,
-  * `javascript`: Turn JavaScript execution on/off (default: `true`) (boolean),
-  * `adblocker`: Turn adblocking on/off (boolean),
-  * `cookie-jar`: Uses a netscape formatted cookie jar file at this path
+  * `--uuid`: The UUID of the test profile,
+  * `--device`: Sets the emulated device that the profile will be run on,
+  * `--connection`: Sets the emulated connection speed this profile,
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--json`: Outputs the results of the command in JSON format.,
+  * `--javascript`: Turn JavaScript execution on/off (default: `true`) (boolean),
+  * `--adblocker`: Turn adblocking on/off (boolean),
+  * `--cookie-jar`: Uses a netscape formatted cookie jar file at this path
 
 
 ### calibre site delete-test-profile [options]
 
 Deletes a test profile from a site
 
-Options:
+Flags:
  
-  * `site`: The identifying slug of a site (string),
-  * `uuid`: The UUID of the test profile,
-  * `confirm`: Confirm the deletion,
-  * `json`: Output in JSON format
+  * `--site`: A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command. (string),
+  * `--uuid`: The UUID of the test profile,
+  * `--confirm`: Confirm the deletion,
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre test create <url> [options]
 
 Run a test against any public URL
 
-Options:
+Flags:
  
-  * `device`: Sets the emulated device that the test will be run on,
-  * `location`: The test will be run on a machine in this location,
-  * `connection`: Sets the emulated connection speed for this test,
-  * `adblocker`: Turn adblocking on/off (boolean),
-  * `private`: Private tests are only accessible by logged in team members (boolean),
-  * `cookie-jar`: Uses a netscape formatted cookie jar file at this path,
-  * `headers`: Stringify'd JSON HTTP Header key/value pairs or path to JSON file of HTTP Header key/value pairs ,
-  * `json`: Output in JSON format,
-  * `waitForTest`: Wait for test to complete before returning (boolean)
+  * `--device`: Sets the emulated device that the test will be run on,
+  * `--location`: The test will be run on a machine in this location,
+  * `--connection`: Sets the emulated connection speed for this test,
+  * `--adblocker`: Turn adblocking on/off (boolean),
+  * `--private`: Private tests are only accessible by logged in team members (boolean),
+  * `--cookie-jar`: Uses a netscape formatted cookie jar file at this path,
+  * `--headers`: Stringify'd JSON HTTP Header key/value pairs or path to JSON file of HTTP Header key/value pairs ,
+  * `--json`: Outputs the results of the command in JSON format.,
+  * `--waitForTest`: Wait for test to complete before returning (boolean)
 
 
 ### calibre test download-artifacts <uuid>
 
 Downloads the artifacts of a test to ./test-artifacts/<uuid>
 
-Options:
+Flags:
  
-  * `json`: Output in JSON format
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre test list
 
 Print a list of previously run tests
 
-Options:
+Flags:
  
-  * `json`: Output in JSON format
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre test show <uuid>
 
 Print the details of a given test
 
-Options:
+Flags:
  
-  * `json`: Output in JSON format
+  * `--json`: Outputs the results of the command in JSON format.
 
 
 ### calibre connection-list
 
-Print a list of connection speeds
+List all available network connection speeds.
 
-Options:
+Flags:
  
-  * `json`: Print a list of connection speeds as JSON
+  * `--json`: Outputs the results of the command in JSON format.
 
 ### calibre device-list
 
-Print a list of test devices
+List all available test devices.
 
-Options:
+Flags:
  
-  * `json`: Print a list of test devices as JSON
+  * `--json`: Outputs the results of the command in JSON format.
 
 ### calibre location-list
 
-Print a list of test locations
+List all available test locations.
 
-Options:
+Flags:
  
-  * `json`: Print a list of test locations as JSON
+  * `--json`: Outputs the results of the command in JSON format.
 
 ### calibre metric-list
 
-Print a list of metrics
+List all available web performance metrics.
 
-Options:
+Flags:
  
-  * `json`: Print a list of metrics as JSON
+  * `--json`: Outputs the results of the command in JSON format.
 
-### calibre token set <key>
+### calibre token set <token>
 
-Set the Calibre API token used for CLI commands
+Store your API Token to use the CLI (saved in ~/.config/configstore/calibre.json).
 
-Options:
- 
+
 
 
 ### calibre token remove
 
-Remove the Calibre API token used for CLI commands
+Remove the saved API Token used for CLI commands (from ~/.config/configstore/calibre.json).
 
-Options:
- 
+
 
 
 ### calibre request
 
-Make a request to the Calibre GraphQL API
+Use the request command to make a request to the Calibre GraphQL API.
 
-Options:
+Flags:
  
-  * `query`: GraphQL query to execute. e.g.:
-
-calibre request --query='query GetSite($slug: String!) {organisation{site(slug: $slug){slug}}}' --slug=calibre (string),
-  * `variables`: Pass query variables as named arguments
+  * `--query`: Pass a GraphQL query to execute. (string),
+  * `--variables`: Pass query variables as named arguments.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ calibre --help
 $ calibre <command> --help
 ```
 
-or [see all commands](CLI_COMMANDS.md) in this repository.
+or [see all commands](CLI_COMMANDS.md) in this repository or [Calibre’s documentation](https://calibreapp.com/docs/automation/cli-commands).
 
 In Node, you can use the either ES Modules or CommonJS versions accordingly:
 

--- a/__tests__/cli/__snapshots__/index.test.js.snap
+++ b/__tests__/cli/__snapshots__/index.test.js.snap
@@ -5,15 +5,22 @@ exports[`calibre --help 1`] = `
 
 Commands:
 
-  calibre site <command>   Site management commands
-  calibre test <command>   Single page tests
-  calibre connection-list  Print a list of connection speeds
-  calibre device-list      Print a list of test devices
-  calibre location-list    Print a list of test locations
-  calibre metric-list      Print a list of metrics
-  calibre token <command>  Store or revoke a Calibre API token (Use instead of C
-                           ALIBRE_API_TOKEN environment variable)
-  calibre request          Make a request to the Calibre GraphQL API
+  calibre site <command>   Use the site command to manage your Sites, Pages, Tes
+                           t Profiles, Deploys, Snapshots and download the monit
+                           oring data.
+  calibre test <command>   Use the test command to run Single Page Tests: public
+                            or private tests for a single Page tested from a sin
+                           gle device. This command also supports viewing all Si
+                           ngle Page Tests and retrieving their artifacts.
+  calibre connection-list  List all available network connection speeds.
+  calibre device-list      List all available test devices.
+  calibre location-list    List all available test locations.
+  calibre metric-list      List all available web performance metrics.
+  calibre token <command>  Use the token command to store or revoke a Calibre AP
+                           I token. You can also save your token with the CALIBR
+                           E_API_TOKEN environment variable.
+  calibre request          Use the request command to make a request to the Cali
+                           bre GraphQL API.
 
 Options:
 

--- a/__tests__/cli/__snapshots__/index.test.js.snap
+++ b/__tests__/cli/__snapshots__/index.test.js.snap
@@ -8,6 +8,7 @@ Commands:
   calibre site <command>   Use the site command to manage your Sites, Pages, Tes
                            t Profiles, Deploys, Snapshots and download the monit
                            oring data.
+  calibre team <command>   Use the team command to manage Teams.
   calibre test <command>   Use the test command to run Single Page Tests: public
                             or private tests for a single Page tested from a sin
                            gle device. This command also supports viewing all Si

--- a/__tests__/cli/__snapshots__/request.test.js.snap
+++ b/__tests__/cli/__snapshots__/request.test.js.snap
@@ -7,18 +7,14 @@ exports[`request missing query argument 1`] = `
 
  calibre request
 
-Make a request to the Calibre GraphQL API
+Use the request command to make a request to the Calibre GraphQL API.
 
 Options:
 
   --help       Show help                                               [boolean]
   --version    Show version number                                     [boolean]
-  --query      GraphQL query to execute. e.g.:
-
-               calibre request --query='query G
-               etSite($slug: String!) {organisation{site(slug: $slug){slug}}}' -
-               -slug=calibre                                 [string] [required]
-  --variables  Pass query variables as named arguments"
+  --query      Pass a GraphQL query to execute.              [string] [required]
+  --variables  Pass query variables as named arguments."
 `;
 
 exports[`request returns response 1`] = `

--- a/__tests__/cli/__snapshots__/site.test.js.snap
+++ b/__tests__/cli/__snapshots__/site.test.js.snap
@@ -13,10 +13,13 @@ Options:
 
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
-  --site     The identifying slug of a site                  [string] [required]
-  --count    The number of records to return, maximum: 500         [default: 25]
+  --site     A unique slug identifying each Site. You can find it in Site Settin
+             gs → General or by using the calibre site list command.
+                                                             [string] [required]
+  --count    The number of items to return (default: 25, maximum: 500).
+                                                                   [default: 25]
   --cursor   The cursor to fetch records after
-  --json     Output in JSON format"
+  --json     Outputs the results of the command in JSON format."
 `;
 
 exports[`missing site argument value 1`] = `
@@ -32,8 +35,11 @@ Options:
 
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
-  --site     The identifying slug of a site                  [string] [required]
-  --count    The number of records to return, maximum: 500         [default: 25]
+  --site     A unique slug identifying each Site. You can find it in Site Settin
+             gs → General or by using the calibre site list command.
+                                                             [string] [required]
+  --count    The number of items to return (default: 25, maximum: 500).
+                                                                   [default: 25]
   --cursor   The cursor to fetch records after
-  --json     Output in JSON format"
+  --json     Outputs the results of the command in JSON format."
 `;

--- a/__tests__/cli/__snapshots__/site.test.js.snap
+++ b/__tests__/cli/__snapshots__/site.test.js.snap
@@ -7,7 +7,7 @@ exports[`missing site argument 1`] = `
 
  calibre site pages [options]
 
-Print a list of pages for a given site
+List Pages for a selected Site.
 
 Options:
 
@@ -29,7 +29,7 @@ exports[`missing site argument value 1`] = `
 
  calibre site pages [options]
 
-Print a list of pages for a given site
+List Pages for a selected Site.
 
 Options:
 

--- a/__tests__/cli/__snapshots__/team.test.js.snap
+++ b/__tests__/cli/__snapshots__/team.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`missing subcommand 1`] = `
+"
+
+ Not enough non-option arguments: got 0, need at least 1 
+
+ calibre team <command>
+
+Use the team command to manage Teams.
+
+Commands:
+
+  calibre team list  List Teams based on API Token access. For Admin Tokens, thi
+                     s will list all teams or as specified based on your setting
+                     s. For Personal Access Tokens, this will list Teams that yo
+                     u have access to.
+
+Options:
+
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]"
+`;

--- a/__tests__/cli/site/__snapshots__/delete-deploy.test.js.snap
+++ b/__tests__/cli/site/__snapshots__/delete-deploy.test.js.snap
@@ -18,8 +18,10 @@ Options:
 
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
-  --site     The identifying slug of a site                  [string] [required]
+  --site     A unique slug identifying each Site. You can find it in Site Settin
+             gs → General or by using the calibre site list command.
+                                                             [string] [required]
   --uuid     The uuid of the deploy                                   [required]
   --confirm  Confirm the deletion
-  --json     Output in JSON format"
+  --json     Outputs the results of the command in JSON format."
 `;

--- a/__tests__/cli/site/__snapshots__/delete-deploy.test.js.snap
+++ b/__tests__/cli/site/__snapshots__/delete-deploy.test.js.snap
@@ -12,7 +12,7 @@ exports[`site delete-deploy requires uuid 1`] = `
 
  calibre site delete-deploy [options]
 
-Deletes a deploy from a site
+Delete a deploy from a selected Site.
 
 Options:
 
@@ -21,7 +21,7 @@ Options:
   --site     A unique slug identifying each Site. You can find it in Site Settin
              gs → General or by using the calibre site list command.
                                                              [string] [required]
-  --uuid     The uuid of the deploy                                   [required]
-  --confirm  Confirm the deletion
+  --uuid     The UUID of the deploy.                                  [required]
+  --confirm  Use this flag to confirm the deletion of the selected deploy.
   --json     Outputs the results of the command in JSON format."
 `;

--- a/__tests__/cli/site/__snapshots__/delete-snapshot.test.js.snap
+++ b/__tests__/cli/site/__snapshots__/delete-snapshot.test.js.snap
@@ -18,8 +18,10 @@ Options:
 
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
-  --site     The identifying slug of a site                  [string] [required]
+  --site     A unique slug identifying each Site. You can find it in Site Settin
+             gs → General or by using the calibre site list command.
+                                                             [string] [required]
   --id       The id of the snapshot                                   [required]
   --confirm  Confirm the deletion
-  --json     Output in JSON format"
+  --json     Outputs the results of the command in JSON format."
 `;

--- a/__tests__/cli/site/__snapshots__/delete-snapshot.test.js.snap
+++ b/__tests__/cli/site/__snapshots__/delete-snapshot.test.js.snap
@@ -12,7 +12,7 @@ exports[`site delete-snapshot requires id 1`] = `
 
  calibre site delete-snapshot [options]
 
-Deletes a snapshot from a site
+Delete a Snapshot from a selected Site.
 
 Options:
 
@@ -21,7 +21,7 @@ Options:
   --site     A unique slug identifying each Site. You can find it in Site Settin
              gs → General or by using the calibre site list command.
                                                              [string] [required]
-  --id       The id of the snapshot                                   [required]
-  --confirm  Confirm the deletion
+  --id       The id of the Snapshot.                                  [required]
+  --confirm  Use this flag to confirm the deletion of the selected Snapshot.
   --json     Outputs the results of the command in JSON format."
 `;

--- a/__tests__/cli/site/__snapshots__/get-snapshot-metrics.test.js.snap
+++ b/__tests__/cli/site/__snapshots__/get-snapshot-metrics.test.js.snap
@@ -15,8 +15,10 @@ Options:
 
   --help      Show help                                                [boolean]
   --version   Show version number                                      [boolean]
-  --site      The identifying slug of a site                 [string] [required]
+  --site      A unique slug identifying each Site. You can find it in Site Setti
+              ngs → General or by using the calibre site list command.
+                                                             [string] [required]
   --snapshot  The identifying id of a snapshot                        [required]
-  --json      Output in JSON format
-  --csv       Output in CSV format"
+  --json      Outputs the results of the command in JSON format.
+  --csv       Outputs the results of the command in CSV format."
 `;

--- a/__tests__/cli/site/__snapshots__/get-snapshot-metrics.test.js.snap
+++ b/__tests__/cli/site/__snapshots__/get-snapshot-metrics.test.js.snap
@@ -9,7 +9,7 @@ exports[`snapshot metrics returns no snapshot error 1`] = `
 
  calibre site get-snapshot-metrics [options]
 
-Get the metrics of a given snapshot
+Get all metrics of a given Snapshot.
 
 Options:
 
@@ -18,7 +18,7 @@ Options:
   --site      A unique slug identifying each Site. You can find it in Site Setti
               ngs → General or by using the calibre site list command.
                                                              [string] [required]
-  --snapshot  The identifying id of a snapshot                        [required]
+  --snapshot  The id of a Snapshot.                                   [required]
   --json      Outputs the results of the command in JSON format.
   --csv       Outputs the results of the command in CSV format."
 `;

--- a/__tests__/cli/team.test.js
+++ b/__tests__/cli/team.test.js
@@ -1,0 +1,6 @@
+import { runCLI } from '../utils'
+
+test('missing subcommand', async () => {
+  const out = await runCLI({ args: 'team', testForError: true })
+  expect(out).toMatchSnapshot()
+})

--- a/__tests__/cli/team/__snapshots__/list.test.js.snap
+++ b/__tests__/cli/team/__snapshots__/list.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`team list lists all teams 1`] = `
+"2 sites
+SLUG        | NAME     | DESCRIPTION     
+calibre     | Calibre  | Default team    
+engineering | Monitors | Engineering team"
+`;

--- a/__tests__/cli/team/list.test.js
+++ b/__tests__/cli/team/list.test.js
@@ -1,0 +1,19 @@
+import {
+  runCLI,
+  setupIntegrationServer,
+  teardownIntegrationServer
+} from '../../utils'
+
+import listTeams from '../../fixtures/listTeams.json'
+
+describe('team list', () => {
+  beforeAll(() => setupIntegrationServer(listTeams))
+  afterAll(() => teardownIntegrationServer())
+
+  test('lists all teams', async () => {
+    const out = await runCLI({
+      args: 'team list'
+    })
+    expect(out).toMatchSnapshot()
+  })
+})

--- a/__tests__/cli/token/__snapshots__/set.test.js.snap
+++ b/__tests__/cli/token/__snapshots__/set.test.js.snap
@@ -7,13 +7,15 @@ exports[`missing token argument 1`] = `
 
  calibre token <command>
 
-Store or revoke a Calibre API token (Use instead of CALIBRE_API_TOKEN environmen
-t variable)
+Use the token command to store or revoke a Calibre API token. You can also save
+your token with the CALIBRE_API_TOKEN environment variable.
 
 Commands:
 
-  calibre token set <key>  Set the Calibre API token used for CLI commands
-  calibre token remove     Remove the Calibre API token used for CLI commands
+  calibre token set <token>  Store your API Token to use the CLI (saved in ~/.co
+                             nfig/configstore/calibre.json).
+  calibre token remove       Remove the saved API Token used for CLI commands (f
+                             rom ~/.config/configstore/calibre.json).
 
 Options:
 

--- a/__tests__/fixtures/listTeams.json
+++ b/__tests__/fixtures/listTeams.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "organisation": {
+      "teams": [
+        {
+          "name": "Calibre",
+          "description": "Default team",
+          "slug": "calibre"
+        },
+        {
+          "name": "Monitors",
+          "description": "Engineering team",
+          "slug": "engineering"
+        }
+      ]
+    }
+  }
+}

--- a/generate-cli-md.js
+++ b/generate-cli-md.js
@@ -9,14 +9,19 @@ ${describe || ''}
 }
 
 const formatOptions = options => {
-  return `Options:
- ${Object.keys(options).map(key => {
+  const optionKeys = Object.keys(options)
+  if (!optionKeys.length) {
+    return ''
+  } else {
+    return `Flags:
+ ${optionKeys.map(key => {
    const { describe, default: defaultValue, type } = options[key]
    return `
-  * \`${key}\`: ${describe}${
+  * \`--${key}\`: ${describe}${
      defaultValue ? ` (default: \`${defaultValue}\`)` : ''
    }${type ? ` (${type})` : ''}`
  })}`
+  }
 }
 
 const template = command => {
@@ -41,8 +46,6 @@ const template = command => {
 }
 
 const commands = getCommandMetaData()
-
-// console.log(JSON.stringify(commands, null, 2))
 
 let output = ''
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calibre",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calibre",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "engines": {
     "node": ">= 14.18"
   },

--- a/src/api/team.js
+++ b/src/api/team.js
@@ -1,0 +1,20 @@
+import { request } from './graphql.js'
+
+const LIST_QUERY = `
+  query {
+    organisation {
+      teams {
+        name
+        description
+        slug
+      }
+    }
+  }
+`
+
+const list = async () => {
+  const response = await request({ query: LIST_QUERY })
+  return response.organisation.teams
+}
+
+export { list }

--- a/src/cli-commands.js
+++ b/src/cli-commands.js
@@ -4,11 +4,13 @@ import * as LocationList from './cli/location-list.js'
 import * as MetricList from './cli/metric-list.js'
 import * as Request from './cli/request.js'
 import * as Site from './cli/site.js'
+import * as Team from './cli/team.js'
 import * as Test from './cli/test.js'
 import * as Token from './cli/token.js'
 
 const commands = [
   Site,
+  Team,
   Test,
   ConnectionList,
   DeviceList,

--- a/src/cli/connection-list.js
+++ b/src/cli/connection-list.js
@@ -4,6 +4,7 @@ import columnify from 'columnify'
 
 import { list } from '../api/connection.js'
 import { humaniseError } from '../utils/api-error.js'
+import { options } from '../utils/cli'
 
 const main = async args => {
   let index
@@ -42,12 +43,10 @@ const main = async args => {
 }
 
 const command = 'connection-list'
-const describe = 'Print a list of connection speeds'
+const describe = 'List all available network connection speeds.'
 const handler = main
 const builder = {
-  json: {
-    describe: `${describe} as JSON`
-  }
+  json: options.json
 }
 
 export { command, describe, handler, builder }

--- a/src/cli/connection-list.js
+++ b/src/cli/connection-list.js
@@ -4,7 +4,7 @@ import columnify from 'columnify'
 
 import { list } from '../api/connection.js'
 import { humaniseError } from '../utils/api-error.js'
-import { options } from '../utils/cli'
+import { options } from '../utils/cli.js'
 
 const main = async args => {
   let index

--- a/src/cli/device-list.js
+++ b/src/cli/device-list.js
@@ -4,7 +4,7 @@ import columnify from 'columnify'
 
 import { list } from '../api/device.js'
 import { humaniseError } from '../utils/api-error.js'
-import { options } from '../utils/cli'
+import { options } from '../utils/cli.js'
 
 const main = async args => {
   let index

--- a/src/cli/device-list.js
+++ b/src/cli/device-list.js
@@ -4,6 +4,7 @@ import columnify from 'columnify'
 
 import { list } from '../api/device.js'
 import { humaniseError } from '../utils/api-error.js'
+import { options } from '../utils/cli'
 
 const main = async args => {
   let index
@@ -42,12 +43,10 @@ const main = async args => {
 }
 
 const command = 'device-list'
-const describe = 'Print a list of test devices'
+const describe = 'List all available test devices.'
 const handler = main
 const builder = {
-  json: {
-    describe: `${describe} as JSON`
-  }
+  json: options.json
 }
 
 export { command, describe, handler, builder }

--- a/src/cli/location-list.js
+++ b/src/cli/location-list.js
@@ -4,7 +4,7 @@ import columnify from 'columnify'
 
 import { list } from '../api/location.js'
 import { humaniseError } from '../utils/api-error.js'
-import { options } from '../utils/cli'
+import { options } from '../utils/cli.js'
 
 const main = async args => {
   let index

--- a/src/cli/location-list.js
+++ b/src/cli/location-list.js
@@ -4,6 +4,7 @@ import columnify from 'columnify'
 
 import { list } from '../api/location.js'
 import { humaniseError } from '../utils/api-error.js'
+import { options } from '../utils/cli'
 
 const main = async args => {
   let index
@@ -45,12 +46,10 @@ const main = async args => {
 }
 
 const command = 'location-list'
-const describe = 'Print a list of test locations'
+const describe = 'List all available test locations.'
 const handler = main
 const builder = {
-  json: {
-    describe: `${describe} as JSON`
-  }
+  json: options.json
 }
 
 export { command, describe, handler, builder }

--- a/src/cli/metric-list.js
+++ b/src/cli/metric-list.js
@@ -6,6 +6,7 @@ import logSymbols from 'log-symbols'
 import { list } from '../api/metric.js'
 import { humaniseError } from '../utils/api-error.js'
 import { format } from '../utils/formatters/index.js'
+import { options } from '/utils/cli'
 
 const main = async args => {
   let index
@@ -57,12 +58,10 @@ const main = async args => {
 }
 
 const command = 'metric-list'
-const describe = 'Print a list of metrics'
+const describe = 'List all available web performance metrics.'
 const handler = main
 const builder = {
-  json: {
-    describe: `${describe} as JSON`
-  }
+  json: options.json
 }
 
 export { command, describe, handler, builder }

--- a/src/cli/metric-list.js
+++ b/src/cli/metric-list.js
@@ -6,7 +6,7 @@ import logSymbols from 'log-symbols'
 import { list } from '../api/metric.js'
 import { humaniseError } from '../utils/api-error.js'
 import { format } from '../utils/formatters/index.js'
-import { options } from '/utils/cli'
+import { options } from '../utils/cli.js'
 
 const main = async args => {
   let index

--- a/src/cli/request.js
+++ b/src/cli/request.js
@@ -22,11 +22,12 @@ const main = async args => {
 }
 
 const command = 'request'
-const describe = 'Use the request command to make a request to the Calibre GraphQL API.'
+const describe =
+  'Use the request command to make a request to the Calibre GraphQL API.'
 const handler = main
 const builder = {
   query: {
-    describe: `Pass a GraphQL query to execute.`,
+    describe: 'Pass a GraphQL query to execute.',
     demandOption: true,
     type: 'string',
     requiresArg: true

--- a/src/cli/request.js
+++ b/src/cli/request.js
@@ -22,19 +22,17 @@ const main = async args => {
 }
 
 const command = 'request'
-const describe = 'Make a request to the Calibre GraphQL API'
+const describe = 'Use the request command to make a request to the Calibre GraphQL API.'
 const handler = main
 const builder = {
   query: {
-    describe: `GraphQL query to execute. e.g.:
-
-calibre request --query='query GetSite($slug: String!) {organisation{site(slug: $slug){slug}}}' --slug=calibre`,
+    describe: `Pass a GraphQL query to execute.`,
     demandOption: true,
     type: 'string',
     requiresArg: true
   },
   variables: {
-    describe: 'Pass query variables as named arguments'
+    describe: 'Pass query variables as named arguments.'
   }
 }
 

--- a/src/cli/site.js
+++ b/src/cli/site.js
@@ -41,7 +41,7 @@ const commands = [
 ]
 
 const command = 'site <command>'
-const desc = 'Site management commands'
+const desc = 'Use the site command to manage your Sites, Pages, Test Profiles, Deploys, Snapshots and download the monitoring data.'
 const builder = yargs => {
   return yargs.commands(commands)
 }

--- a/src/cli/site/create-deploy.js
+++ b/src/cli/site/create-deploy.js
@@ -27,18 +27,18 @@ const main = async function (args) {
 }
 
 const command = 'create-deploy [options]'
-const describe = 'Create a deploy'
+const describe = 'Create a deployment.'
 const builder = {
   site: options.site,
   revision: {
     describe:
-      'The source control revision id of the code you are deploying (e.g. git hash or tag name)'
+      'The source control revision id of the code you are deploying. It could be a git hash or a tag name.'
   },
   repository: {
     describe:
-      'The base URL of the repository containing the source code being deployed (e.g. https://github.com/calibreapp/app)'
+      'The base URL of the repository containing the source code being deployed (e.g. https://github.com/calibreapp/app).'
   },
-  username: { describe: 'The name of the user who deployed the code' },
+  username: { describe: 'The username of who deployed the code.' },
   json: options.json
 }
 

--- a/src/cli/site/create-page.js
+++ b/src/cli/site/create-page.js
@@ -35,13 +35,13 @@ const main = async function (args) {
 }
 
 const command = 'create-page <name> [options]'
-const describe = 'Add a page to an existing site tracked by Calibre'
+const describe = 'Add a Page to an existing Site tracked by Calibre.'
 const builder = {
   site: options.site,
   url: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The name of the page'
+    describe: 'The name of the Page.'
   },
   json: options.json
 }

--- a/src/cli/site/create-snapshot.js
+++ b/src/cli/site/create-snapshot.js
@@ -27,10 +27,10 @@ const main = async function (args) {
 }
 
 const command = 'create-snapshot [options]'
-const describe = 'Create a snapshot'
+const describe = 'Create a Snapshot.'
 const builder = {
   site: options.site,
-  ref: { describe: 'Sets a reference to the snapshot' },
+  ref: { describe: 'Set a reference to the Snapshot.' },
   json: options.json
 }
 const handler = main

--- a/src/cli/site/create-test-profile.js
+++ b/src/cli/site/create-test-profile.js
@@ -45,27 +45,27 @@ const main = async function (args) {
 }
 
 const command = 'create-test-profile <name> [options]'
-const describe = 'Add a test profile to a site'
+const describe = 'Add a Test Profile to a Site.'
 const builder = {
   site: options.site,
   device: {
-    describe: 'Sets the emulated device that the profile will be run on'
+    describe: 'Choose the emulated test device.'
   },
   connection: {
-    describe: 'Sets the emulated connection speed this profile'
+    describe: 'Choose the emulated network connection speed.'
   },
   javascript: {
     type: 'boolean',
-    describe: 'Turn JavaScript execution on/off',
+    describe: 'Turn JavaScript execution on or off.',
     default: true
   },
   adblocker: {
     type: 'boolean',
-    describe: 'Turn adblocking on/off',
+    describe: 'Turn adblocking on or off.',
     default: false
   },
   'cookie-jar': {
-    describe: 'Uses a netscape formatted cookie jar file at this path'
+    describe: 'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
   },
   json: options.json
 }

--- a/src/cli/site/create.js
+++ b/src/cli/site/create.js
@@ -74,29 +74,29 @@ const main = async function (args) {
 }
 
 const command = 'create <name> [options]'
-const describe = 'Add a site for Calibre to monitor'
+const describe = 'Add a Site for Calibre to monitor.'
 const builder = {
   url: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The homepage URL of the site'
+    describe: 'The URL of the Site.'
   },
   location: {
     demandOption: true,
     requiresArg: true,
-    describe: 'Calibre will monitor from this location'
+    describe: 'Choose the location for the test.'
   },
   team: {
-    describe: 'The identifying slug of the team'
+    describe: 'The identifying slug of the Team.'
   },
   schedule: {
     describe:
-      'Schedule for automated snapshots. One of: hourly, daily, every_x_hours',
+      'Set the schedule for automated Snapshots. Available options: hourly, daily, every_x_hours.',
     default: 'every_x_hours'
   },
   interval: {
     describe:
-      "Automated snapshot interval. UTC hour of day for 'daily', hour interval for 'every_x_hours'",
+      'Set the Snapshot interval. Provide UTC hour (between 0 and 23) for daily Snapshots and numeric hour interval for every_x_hours option (between 1 and 168 hours).',
     default: 6
   },
   json: options.json

--- a/src/cli/site/delete-deploy.js
+++ b/src/cli/site/delete-deploy.js
@@ -15,7 +15,7 @@ const main = async function (args) {
 
   if (process.stdout.isTTY && !args.confirm) {
     return new Error(
-      'Add the --confirm flag to confirm the immediate & irreversible deletion of this deploy.'
+      'Add the --confirm flag to confirm the immediate and irreversible deletion of this deploy.'
     )
   }
 
@@ -33,16 +33,16 @@ const main = async function (args) {
 }
 
 const command = 'delete-deploy [options]'
-const describe = 'Deletes a deploy from a site'
+const describe = 'Delete a deploy from a selected Site.'
 const builder = {
   site: options.site,
   uuid: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The uuid of the deploy'
+    describe: 'The UUID of the deploy.'
   },
   confirm: {
-    describe: 'Confirm the deletion'
+    describe: 'Use this flag to confirm the deletion of the selected deploy.'
   },
   json: options.json
 }

--- a/src/cli/site/delete-page.js
+++ b/src/cli/site/delete-page.js
@@ -15,7 +15,7 @@ const main = async function (args) {
 
   if (process.stdout.isTTY && !args.confirm) {
     return new Error(
-      'Add the --confirm flag to confirm the immediate & irreversible deletion of this page.'
+      'Add the --confirm flag to confirm the immediate and irreversible deletion of this Page.'
     )
   }
 
@@ -34,16 +34,16 @@ const main = async function (args) {
 }
 
 const command = 'delete-page [options]'
-const describe = 'Deletes a page from a site'
+const describe = 'Delete a Page from a selected Site.'
 const builder = {
   site: options.site,
   uuid: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The UUID of the page'
+    describe: 'The UUID of the Page.'
   },
   confirm: {
-    describe: 'Confirm the deletion'
+    describe: 'Use this flag to confirm the deletion of the selected Page.'
   },
   json: options.json
 }

--- a/src/cli/site/delete-snapshot.js
+++ b/src/cli/site/delete-snapshot.js
@@ -15,7 +15,7 @@ const main = async function (args) {
 
   if (process.stdout.isTTY && !args.confirm) {
     return new Error(
-      'Add the --confirm flag to confirm the immediate & irreversible deletion of this snapshot.'
+      'Add the --confirm flag to confirm the immediate and irreversible deletion of this Snapshot.'
     )
   }
 
@@ -33,16 +33,16 @@ const main = async function (args) {
 }
 
 const command = 'delete-snapshot [options]'
-const describe = 'Deletes a snapshot from a site'
+const describe = 'Delete a Snapshot from a selected Site.'
 const builder = {
   site: options.site,
   id: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The id of the snapshot'
+    describe: 'The id of the Snapshot.'
   },
   confirm: {
-    describe: 'Confirm the deletion'
+    describe: 'Use this flag to confirm the deletion of the selected Snapshot.'
   },
   json: options.json
 }

--- a/src/cli/site/delete-test-profile.js
+++ b/src/cli/site/delete-test-profile.js
@@ -15,7 +15,7 @@ const main = async function (args) {
 
   if (process.stdout.isTTY && !args.confirm) {
     return new Error(
-      'Add the --confirm flag to confirm the immediate & irreversible deletion of this test profile.'
+      'Add the --confirm flag to confirm the immediate and irreversible deletion of this Test Profile.'
     )
   }
 
@@ -36,16 +36,16 @@ const main = async function (args) {
 }
 
 const command = 'delete-test-profile [options]'
-const describe = 'Deletes a test profile from a site'
+const describe = 'Delete a Test Profile from a Site.'
 const builder = {
   site: options.site,
   uuid: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The UUID of the test profile'
+    describe: 'The UUID of the Test Profile.'
   },
   confirm: {
-    describe: 'Confirm the deletion'
+    describe: 'Use this flag to confirm the deletion of the selected Test Profile.'
   },
   json: options.json
 }

--- a/src/cli/site/delete.js
+++ b/src/cli/site/delete.js
@@ -15,7 +15,7 @@ const main = async function (args) {
 
   if (process.stdout.isTTY && !args.confirm) {
     return new Error(
-      'Add the --confirm flag to confirm the immediate & irreversible deletion of this test profile.'
+      'Add the --confirm flag to confirm the immediate and irreversible deletion of this Site.'
     )
   }
 
@@ -33,10 +33,10 @@ const main = async function (args) {
 }
 
 const command = 'delete <slug> [options]'
-const describe = 'Deletes a site'
+const describe = 'Delete a selected Site.'
 const builder = {
   confirm: {
-    describe: 'Confirm the deletion'
+    describe: 'Use this flag to confirm the deletion of the selected Site.'
   },
   json: options.json
 }

--- a/src/cli/site/deploys.js
+++ b/src/cli/site/deploys.js
@@ -61,7 +61,7 @@ const main = async args => {
 }
 
 const command = 'deploys [options]'
-const describe = 'Print a list of deploys'
+const describe = 'List all deployments for a Site.'
 const handler = main
 const builder = {
   site: options.site,

--- a/src/cli/site/download-snapshot-artifacts.js
+++ b/src/cli/site/download-snapshot-artifacts.js
@@ -163,13 +163,13 @@ const main = async args => {
 
 const command = 'download-snapshot-artifacts [options]'
 const describe =
-  'Downloads the artifacts of a snapshot to ./snapshot-artifacts/<id>'
+  'Download the artifacts of a Snapshot to ./snapshot-artifacts/<id>. Includes: lighthouse.json, render progress screenshots, render progress MP4 video, HAR file (request log) and all other metrics and data available through the Calibre interface.'
 const builder = {
   site: options.site,
   id: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The id of the snapshot'
+    describe: 'The id of the Snapshot.'
   },
   json: options.json
 }

--- a/src/cli/site/get-snapshot-metrics.js
+++ b/src/cli/site/get-snapshot-metrics.js
@@ -93,13 +93,13 @@ const main = async args => {
 }
 
 const command = 'get-snapshot-metrics [options]'
-const describe = 'Get the metrics of a given snapshot'
+const describe = 'Get all metrics of a given Snapshot.'
 const builder = {
   site: options.site,
   snapshot: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The identifying id of a snapshot'
+    describe: 'The id of a Snapshot.'
   },
   json: options.json,
   csv: options.csv

--- a/src/cli/site/list.js
+++ b/src/cli/site/list.js
@@ -46,7 +46,7 @@ const main = async args => {
 }
 
 const command = 'list'
-const describe = 'Print a list of sites being tracked by Calibre'
+const describe = 'List all Sites you are tracking in Calibre.'
 const handler = main
 const builder = {
   json: options.json

--- a/src/cli/site/metrics.js
+++ b/src/cli/site/metrics.js
@@ -50,7 +50,7 @@ const main = async args => {
   }
 }
 const command = 'metrics [options]'
-const describe = 'Get timeseries metrics for a given site'
+const describe = 'Get time-series metrics for a selected Site.'
 const builder = {
   site: options.site,
   pages: options.pages,
@@ -62,7 +62,7 @@ const builder = {
   to: options.to,
   '30-day': {
     describe:
-      'Get the last 30 days of metrics (without this flag, the to and from values will be used)'
+      'Get the last 30 days of metrics. Without this flag, CLI will use the to and from values.'
   }
 }
 const handler = main

--- a/src/cli/site/pages.js
+++ b/src/cli/site/pages.js
@@ -56,7 +56,7 @@ const main = async args => {
 }
 
 const command = 'pages [options]'
-const describe = 'Print a list of pages for a given site'
+const describe = 'List Pages for a selected Site.'
 const handler = main
 const builder = {
   site: options.site,

--- a/src/cli/site/snapshots.js
+++ b/src/cli/site/snapshots.js
@@ -64,7 +64,7 @@ const main = async args => {
 }
 
 const command = 'snapshots [options]'
-const describe = 'Print a list of snapshots'
+const describe = 'List selected Snapshots for a Site.'
 const handler = main
 const builder = {
   site: options.site,

--- a/src/cli/site/test-profiles.js
+++ b/src/cli/site/test-profiles.js
@@ -50,7 +50,7 @@ const main = async args => {
 }
 
 const command = 'test-profiles [options]'
-const describe = 'Print a list of test profiles for a given site'
+const describe = 'List all Test Profiles for a Site.'
 const handler = main
 const builder = {
   site: options.site,

--- a/src/cli/site/update-page.js
+++ b/src/cli/site/update-page.js
@@ -37,15 +37,15 @@ const main = async function (args) {
 }
 
 const command = 'update-page [options]'
-const describe = 'Update the name and/or URL of a page'
+const describe = 'Update the name or URL of a Page.'
 const builder = {
   uuid: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The UUID of the page'
+    describe: 'The UUID of the Page.'
   },
-  name: { describe: 'The name of the page' },
-  url: { describe: 'The URL of the page' },
+  name: { describe: 'Update the name of the Page.' },
+  url: { describe: 'Update the URL of the Page.' },
   site: options.site,
   json: options.json
 }

--- a/src/cli/site/update-test-profile.js
+++ b/src/cli/site/update-test-profile.js
@@ -31,7 +31,7 @@ const main = async function (args) {
     const response = await update({ ...args, cookies })
     if (!args.json) {
       spinner.succeed(
-        `Test profile updated: ${response.name} (${response.uuid})`
+        `Test Profile updated: ${response.name} (${response.uuid})`
       )
       console.log(formatProfile(response))
     }
@@ -46,33 +46,33 @@ const main = async function (args) {
   }
 }
 const command = 'update-test-profile [options]'
-const describe = 'Update a test profile. Only updates attributes sent.'
+const describe = 'Update Test Profile settings. Only changes specified attributes.'
 const builder = {
   uuid: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The UUID of the test profile'
+    describe: 'The UUID of the Test Profile.'
   },
   device: {
-    describe: 'Sets the emulated device that the profile will be run on'
+    describe: 'Set the emulated device.'
   },
   connection: {
-    describe: 'Sets the emulated connection speed this profile'
+    describe: 'Set the emulated network connection speed.'
   },
   site: options.site,
   json: options.json,
   javascript: {
     type: 'boolean',
-    describe: 'Turn JavaScript execution on/off',
+    describe: 'Turn JavaScript execution on or off',
     default: true
   },
   adblocker: {
     type: 'boolean',
-    describe: 'Turn adblocking on/off',
+    describe: 'Turn adblocking on or off.',
     default: false
   },
   'cookie-jar': {
-    describe: 'Uses a netscape formatted cookie jar file at this path'
+    describe: 'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
   }
 }
 

--- a/src/cli/team.js
+++ b/src/cli/team.js
@@ -1,0 +1,12 @@
+import * as TeamList from './team/list.js'
+
+const commands = [TeamList]
+
+const command = 'team <command>'
+const desc = 'Use the team command to manage Teams.'
+const builder = yargs => {
+  return yargs.commands(commands)
+}
+const handler = () => {}
+
+export { command, desc, builder, handler, commands }

--- a/src/cli/team/list.js
+++ b/src/cli/team/list.js
@@ -1,0 +1,55 @@
+import chalk from 'chalk'
+import ora from 'ora'
+import columnify from 'columnify'
+
+import { list } from '../../api/team.js'
+import { options } from '../../utils/cli.js'
+import { humaniseError } from '../../utils/api-error.js'
+
+const main = async args => {
+  let index
+  let spinner
+  if (!args.json) {
+    spinner = ora('Connecting to Calibre')
+    spinner.color = 'magenta'
+    spinner.start()
+  }
+
+  try {
+    index = await list(args)
+    if (args.json) return console.log(JSON.stringify(index, null, 2))
+  } catch (e) {
+    if (args.json) return console.error(e)
+    spinner.fail()
+    throw new Error(humaniseError(e))
+  }
+
+  spinner.stop()
+  console.log(`${chalk.bold(index.length)} sites`)
+
+  const rows = index.map(row => {
+    return {
+      slug: chalk.grey(row.slug),
+      name: row.name,
+      description: row.description
+    }
+  })
+
+  console.log(
+    columnify(rows, {
+      columnSplitter: ' | ',
+      truncate: true,
+      maxLineWidth: 'auto'
+    })
+  )
+}
+
+const command = 'list'
+const describe =
+  'List Teams based on API Token access. For Admin Tokens, this will list all teams or as specified based on your settings. For Personal Access Tokens, this will list Teams that you have access to.'
+const handler = main
+const builder = {
+  json: options.json
+}
+
+export { command, describe, builder, handler }

--- a/src/cli/test.js
+++ b/src/cli/test.js
@@ -6,7 +6,7 @@ import * as TestShow from './test/show.js'
 const commands = [TestCreate, TestDownloadArtifacts, TestList, TestShow]
 
 const command = 'test <command>'
-const desc = 'Single page tests'
+const desc = 'Use the test command to run Single Page Tests: public or private tests for a single Page tested from a single device. This command also supports viewing all Single Page Tests and retrieving their artifacts.'
 const builder = yargs => {
   return yargs.commands(commands)
 }

--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -89,39 +89,39 @@ const main = async function (args) {
 }
 
 const command = 'create <url> [options]'
-const describe = 'Run a test against any public URL'
+const describe = 'Run a Single Page Test against any public URL.'
 const builder = {
   device: {
-    describe: 'Sets the emulated device that the test will be run on'
+    describe: 'Set the emulated test device.'
   },
   location: {
     demandOption: true,
     requiresArg: true,
-    describe: 'The test will be run on a machine in this location'
+    describe: 'Set the location for the test.'
   },
   connection: {
-    describe: 'Sets the emulated connection speed for this test'
+    describe: 'Set the emulated network connection speed.'
   },
   adblocker: {
-    describe: 'Turn adblocking on/off',
+    describe: 'Turn adblocking on or off.',
     type: 'boolean',
     default: false
   },
   private: {
-    describe: 'Private tests are only accessible by logged in team members',
+    describe: 'Make the results of a test private (only accessible by members of your Calibre organisation).',
     type: 'boolean',
     default: false
   },
   'cookie-jar': {
-    describe: 'Uses a netscape formatted cookie jar file at this path'
+    describe: 'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
   },
   headers: {
     describe:
-      "Stringify'd JSON HTTP Header key/value pairs or path to JSON file of HTTP Header key/value pairs "
+      'Set HTTP headers by providing a path to a JSON file or a valid JSON key-value pairs.'
   },
   json: options.json,
   waitForTest: {
-    describe: 'Wait for test to complete before returning',
+    describe: 'Wait for the test to complete before showing the results (default: test result link is shown immediately).',
     type: 'boolean',
     default: false
   }

--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -92,15 +92,15 @@ const command = 'create <url> [options]'
 const describe = 'Run a Single Page Test against any public URL.'
 const builder = {
   device: {
-    describe: 'Set the emulated test device.'
+    describe: 'Choose the emulated test device.'
   },
   location: {
     demandOption: true,
     requiresArg: true,
-    describe: 'Set the location for the test.'
+    describe: 'Choose the location for the test.'
   },
   connection: {
-    describe: 'Set the emulated network connection speed.'
+    describe: 'Choose the emulated network connection speed.'
   },
   adblocker: {
     describe: 'Turn adblocking on or off.',

--- a/src/cli/test/download-artifacts.js
+++ b/src/cli/test/download-artifacts.js
@@ -61,7 +61,7 @@ const main = async args => {
 }
 
 const command = 'download-artifacts <uuid>'
-const describe = 'Downloads the artifacts of a test to ./test-artifacts/<uuid>'
+const describe = 'Download the artifacts of a test to ./test-artifacts/<uuid>. Includes: lighthouse.json, render progress screenshots, render progress MP4 video, HAR file (request log) and all other metrics and data available through the Calibre interface.'
 const handler = main
 const builder = {
   json: options.json

--- a/src/cli/test/list.js
+++ b/src/cli/test/list.js
@@ -62,7 +62,7 @@ const main = async args => {
 }
 
 const command = 'list'
-const describe = 'Print a list of previously run tests'
+const describe = 'List all previously run Single Page Tests (includes UUID, URL, device, connection, test location and status).'
 const handler = main
 const builder = {
   json: options.json

--- a/src/cli/test/show.js
+++ b/src/cli/test/show.js
@@ -30,7 +30,7 @@ const main = async args => {
 }
 
 const command = 'show <uuid>'
-const describe = 'Print the details of a given test'
+const describe = 'See the results of a Single Page Test (also as outputted by the test create command).'
 const handler = main
 const builder = {
   json: options.json

--- a/src/cli/token.js
+++ b/src/cli/token.js
@@ -5,7 +5,7 @@ const commands = [TokenSet, TokenRemove]
 
 const command = 'token <command>'
 const desc =
-  'Store or revoke a Calibre API token (Use instead of CALIBRE_API_TOKEN environment variable)'
+  'Use the token command to store or revoke a Calibre API token. You can also save your token with the CALIBRE_API_TOKEN environment variable.'
 const builder = yargs => {
   return yargs.commands(commands)
 }

--- a/src/cli/token/remove.js
+++ b/src/cli/token/remove.js
@@ -7,14 +7,14 @@ const config = new Configstore('calibre')
 const main = async () => {
   if (config.get('token')) {
     config.set('token', null)
-    console.log(`${chalk.bold.green(`${logSymbols.success} Token removed!`)}\n`)
+    console.log(`${chalk.bold.green(`${logSymbols.success} API Token removed.`)}\n`)
   } else {
-    console.log(`${chalk.bold.red(`${logSymbols.error} Token is not set!`)}\n`)
+    console.log(`${chalk.bold.red(`${logSymbols.error} API Token is not set.`)}\n`)
   }
 }
 
 const command = 'remove'
-const describe = 'Remove the Calibre API token used for CLI commands'
+const describe = 'Remove the saved API Token used for CLI commands (from ~/.config/configstore/calibre.json).'
 const handler = main
 const builder = {}
 

--- a/src/cli/token/set.js
+++ b/src/cli/token/set.js
@@ -4,13 +4,13 @@ import logSymbols from 'log-symbols'
 
 const config = new Configstore('calibre')
 
-const main = async ({ key }) => {
-  config.set('token', key)
-  console.log(`${chalk.bold.green(`${logSymbols.success} Token saved!`)}\n`)
+const main = async ({ token }) => {
+  config.set('token', token)
+  console.log(`${chalk.bold.green(`${logSymbols.success} API Token saved!`)}\n`)
 }
 
-const command = 'set <key>'
-const describe = 'Set the Calibre API token used for CLI commands'
+const command = 'set <token>'
+const describe = 'Store your API Token to use the CLI (saved in ~/.config/configstore/calibre.json).'
 const handler = main
 const builder = {}
 

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -1,23 +1,23 @@
 const options = {
   site: {
     demandOption: true,
-    describe: 'The identifying slug of a site',
+    describe: 'A unique slug identifying each Site. You can find it in Site Settings → General or by using the calibre site list command.',
     type: 'string',
     requiresArg: true
   },
-  json: { describe: 'Output in JSON format' },
-  csv: { describe: 'Output in CSV format' },
+  json: { describe: 'Outputs the results of the command in JSON format.' },
+  csv: { describe: 'Outputs the results of the command in CSV format.' },
   from: {
     describe:
-      'The start date to retrieve from in the format Year-Month-Day (when not set, defaults to 7 days ago)'
+      'The start date to retrieve data from in the Year-Month-Day format (default: 7 days ago).'
   },
   to: {
     describe:
-      'The end date to retrieve to in the format Year-Month-Day (when not set, defaults to today)'
+      'The end date to retrieve data from in the Year-Month-Day format (default: today).'
   },
   count: {
     default: 25,
-    describe: 'The number of records to return, maximum: 500'
+    describe: 'The number of items to return (default: 25, maximum: 500).'
   },
   cursor: {
     describe: 'The cursor to fetch records after'
@@ -25,17 +25,17 @@ const options = {
   pages: {
     type: 'array',
     describe:
-      'A space separated list of page uuids to return metrics for (when not set, defaults to all pages). eg: --pages=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --pages for each page'
+      'A list of Page UUIDs to return metrics for. You can separate multiple Pages by a space or use multiple --pages flags.'
   },
   profiles: {
     type: 'array',
     describe:
-      'A space separated list of profile uuids to return metrics for (when not set, defaults to all test profiles). eg: --profiles=4a82662c-67dc-40cd-a461-6afc904260f3 51b3cb71-e534-4d48-842a-d8c9da672f55 or use multiple --profiles for each profile'
+      'A list of Test Profile UUIDs to return metrics for. You can separate multiple Test Profiles by a space or use multiple --profiles flags.'
   },
   metrics: {
     type: 'array',
     describe:
-      'A space separated list of metrics to return (when not set, defaults to all metrics). eg: --metrics=first-meaningful-paint first-interactive or use multiple --metrics flags for each metric'
+      'A list of metric UUIDs to return metrics for. You can separate multiple metrics by a space or use multiple --metrics flags.'
   }
 }
 


### PR DESCRIPTION
## What does this PR introduce?

- [x] updates all command descriptions to follow the same nomenclature, be more clear and informative
- [x] renames `options` to `flags` (@benschwarz)
- [x] fixes the bug in `CLI_COMMANDS` where `Options` are listed where not present (@benschwarz)
- [x] Add `calibre team list` command (@benschwarz)
- [x] Bump to 5.0.1