### PR TITLE
✨ Emulated devices API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,36 @@
-# 5.0.1 (2022-05-13)
+# 5.0.2 (2022-07-15)
+
 ## 🚩 Commands and flags
-* Adds a new command: `calibre team list` to list all Teams depending on API Token in use.
+
+- Updates `calibre device-list` command to output additional emulated device details (screen width and height, device type: `phone` `tablet` or `desktop` and status: `current` or `discontinued`)
+
+# 5.0.1 (2022-05-13)
+
+## 🚩 Commands and flags
+
+- Adds a new command: `calibre team list` to list all Teams depending on API Token in use.
 
 ## 🛠 Core
-* Updates all command and flag descriptions for clarity and accuracy.
+
+- Updates all command and flag descriptions for clarity and accuracy.
 
 ## 📖 Documentation
-* updates `README.md` to include link to Calibre’s documentation page for all CLI commands
+
+- updates `README.md` to include link to Calibre’s documentation page for all CLI commands
 
 # 5.0.0 (2022-04-29)
 
 ## 💥 Breaking changes
+
 - Ends support for [Node 12](https://nodejs.org/en/about/releases/) (end of life as of `2022-04-30`).
 - Discontinues packaged binary builds: releases only via [npm](https://www.npmjs.com/package/calibre).
 
 ## 🚩 Commands and flags
+
 - Adds a new flag for `calibre test create`: `--waitForTest` (default: `false`).
 
 ## 🛠 Core
+
 - Adds a new package export: `cli-commands` (returns all command functions and CLI options).
 - Adds a new package export: `cli-metadata` (returns all command documentation).
 - Adds a new package script: `npm run generate-cli-md` (generates `CLI_COMMANDS.md` CLI documentation file).
@@ -26,9 +39,11 @@
 - Adds built-in throttling to requests made with the API so they don't hit the request limit.
 
 ## 🧹 Housekeeping
+
 - Turns `ESLint` on for the build process.
 
 ## 📖 Documentation
+
 - Updates `README.md` to reflect current usage.
 - Updates all Node.js examples to ES Modules.
 - Adds `CLI_COMMANDS.md` that showcases all available commands and subcommands with their options.
@@ -79,48 +94,58 @@
 # 3.2.2 (2021-04-16)
 
 ## 🛠 Core
+
 - Updates Timeseries API: Return `page` for `series` data.
 
 # 3.2.1 (2021-02-02)
 
 ## 🐛 Bugs
+
 - Fixes Timeseries API: Filter by Profile.
 
 ## 🧹 Housekeeping
+
 - Updates dependencies, inclusive of latest security patches.
 
 # 3.2.0 (2020-10-07)
 
 ## 🐛 Bugs
+
 - Fixes `site create-test-profile` to default JavaScript execution to on.
 - Fixes `more information` link.
 
 # 3.1.1 (2020-04-23)
 
 ## 🐛 Bugs
+
 - Fixes reference to `token set` in error message.
 
 ## 🚩 Commands and flags
+
 - Updates `get-pulse-metrics` description.
 
 # 3.1.0 (2020-03-26)
 
 ## 🛠 Core
+
 - Adds support for formatting `milliunit` measurements.
 
 # 3.0.2 (2020-03-05)
 
 ## 🐛 Bugs
+
 - Fixes parsing of `to` and `from` arguments in the `get-pulse-metrics` command.
 
 # 3.0.1 (2020-03-04)
 
 ## 🛠 Core
+
 - Allows use of token store for Node.
 
 # 3.0.0 (2020-02-07)
 
 ## 🚩 Commands and flags
+
 - Adds `calibre token set` command.
 - Adds `calibre token remove` command.
 - Adds ability to get Test Agent settings in `agentSettings` API.
@@ -130,47 +155,56 @@
 - Updates `create site` to have same defaults as web.
 
 ## 🛠 Core
+
 - Updates default host to https://api.calibreapp.com.
 - Improves error handling when trying to `get-snapshot-metrics` for a snapshot
   that does not exist.
 - Supports Node version ≥ `10.13.0` (the first version of 10.x that was considered LTS).
 
 ## 🐛 Bugs
+
 - Fixes undefined `ref` when creating a snapshot in API without a `ref`.
 
 # 2.4.0 (2019-12-03)
 
 ## 🚩 Commands and flags
+
 - Adds the ability to set `isPrivate` in `test` API.
 - Adds `--private` flag to create a private test.
 
 # 2.3.2 (2019-08-08)
 
 ## 🚩 Commands and flags
+
 - Updates the TimeSeries api to return `uuid` and `canonical` for `pages` and `uuid`, `name`, `jsIsDisabled`, `adBlockIsEnabled`, `hasDeviceEmulation`, `hasBandwidthEmulation` and `isMobile` for `testProfiles`.
 
 # 2.3.1 (2019-07-23)
 
 ## 🛠 Core
+
 - Set default count in `deploys` API.
 
 ## 🐛 Bugs
+
 - Fixes `destroy` mutation in `snapshot` API to pass `String` to GraphQL API.
 
 # 2.3.0 (2019-07-15)
 
 ## 🚩 Commands and flags
+
 - Adds ability to add custom headers in `test` API.
 - Adds `--headers` flag to create test with custom headers.
 
 # 2.2.1 (2019-07-06)
 
 ## 🧹 Housekeeping
+
 - Updated `.npmignore` so that development data isn’t included in the package.
 
 # 2.2.0 - 2019-07-05
 
 ## 🚩 Commands and flags
+
 - Adds `integrations` to to API.
 - Adds `metric-budgets` to to API.
 - Adds `agent-settings` to to API.
@@ -178,21 +212,25 @@
 # 2.1.0 (2019-06-12)
 
 ## 🛠 Core
+
 - Changes `calibre site pages` to use paginated query method.
 
 # 2.0.2 (2019-05-20)
 
 ## 🛠 Core
+
 - Updates `api-error` util to get GraphQL errors from `extensions`.
 
 # 2.0.1 (2019-05-17)
 
 ## 🐛 Bugs
+
 - Fixes test output to only display metric if available.
 
 # 2.0.0 (2019-04-30)
 
 ## 🚩 Commands and flags
+
 - Adds `calibre site deploys` command.
 - Adds `calibre site create-deploy` command.
 - Adds `calibre site delete-deploy` command.
@@ -208,6 +246,7 @@
 - Changes `calibre site create test` to show the error or timeout failure.
 
 ## 🛠 Core
+
 - Updated formatting of Lighthouse scores for Single Page Tests.
 - Changed the metrics chart for Single Page Tests to show First Contentful Paint instead of First Meaningful Paint.
 - Removes GIF download from `download-snapshot-artifacts`.
@@ -215,21 +254,25 @@
 # 1.2.4 (2019-03-18)
 
 ## 🐛 Bugs
+
 - Fixes output of request result (format with `JSON`).
 
 # 1.2.3 (2019-03-11)
 
 ## 🐛 Bugs
+
 - Fixes Snapshot metrics CSV.
 
 # 1.2.2 (2019-02-28)
 
 ## 🚩 Commands and flags
+
 - Removes `--no-deprecation` flag.
 
 # 1.2.1 (2019-02-21)
 
 ## 🚩 Commands and flags
+
 - Removed `await-for-of` to continue support for Node 8.
 - Changed `download-artifact` commands to output relative directory of stored
   artifacts.
@@ -237,6 +280,7 @@
 # 1.2.0 (2019-02-19)
 
 ## 🚩 Commands and flags
+
 - Adds `calibre test download-artifact <uuid>` command.
 - Adds `calibre site download-snapshot-artifacts --site=<slug> <id>` command.
 - Changes `calibre site delete-snapshot` to use `id` rather than `iid`.
@@ -244,6 +288,7 @@
 - Adds `calibre request --query=<graphql query>` command.
 
 ## 🛠 Core
+
 - Changes internal queries to use `hasRecentlyCompletedSnapshots` rather than `hasCompletedSnapshots`.
 - Updates Node API to use `GraphQL.request`.
 - Adds a mock server and utilities for testing.
@@ -251,26 +296,31 @@
 # 1.1.1 (2018-08-22)
 
 ## 🐛 Bugs
+
 - Fixes `--csv` output (#26).
 
 # 1.1.0 (2018-07-20)
 
 ## 🚩 Commands and flags
+
 - Adds `calibre site delete-snapshot` command.
 
 # 1.0.9 (2018-05-11)
 
 ## 🛠 Core
+
 - Switches page objects to use `UUID` (rather than `slug`) to reflect other objects.
 
 # 1.0.8 (2018-05-03)
 
 ## 🐛 Bugs
+
 - Fixes path issue.
 
 # 1.0.7 (2018-05-02)
 
 ## 🚩 Commands and flags
+
 - Adds `calibre site create <name> [options]` command.
 - Adds `calibre site delete` command.
 - Adds `calibre site create-page` command.
@@ -282,13 +332,16 @@
 - Adds `--metrics` flag to `calibre site get-pulse-metrics` command. Specify the metrics you’d like returned.
 
 ## 🛠 Core
+
 - Cleans up internal error handling.
 
 ## 📖 Documentation
+
 - Adds Node.js example for creating a Site using the new `Site.create` method.
 - Adds Node.js example that demonstrates how to create a Single Page Test from every Calibre testing location.
 
 # 1.0.6 (2018-04-14)
 
 ## 🛠 Core
+
 - The `calibre test create` command now accepts a `--cookie-jar` flag. It‘ll use a netscape formatted `cookie-jar` for a given test.

--- a/examples/bash/create-test.sh
+++ b/examples/bash/create-test.sh
@@ -5,7 +5,7 @@ set -e
 # The URL that we will test
 URL=https://calibreapp.com/cli
 TEST_LOCATION=Sydney # To get a list of possible test locations, run `calibre location-list`
-TEST_DEVICE=iPhone8 # To get a list of possible devices, run `calibre device-list`
+TEST_DEVICE=iPhone12 # To get a list of possible devices, run `calibre device-list`
 TEST_CONNECTION=good3G # To get a list of possible connection speeds, run `calibre connection-list`
 
 echo "+++ Running test for $URL (Location: $TEST_LOCATION) (Device: $TEST_DEVICE) (Connection: $TEST_CONNECTION)"

--- a/examples/nodejs/create-test.js
+++ b/examples/nodejs/create-test.js
@@ -8,7 +8,7 @@ const createTest = async () => {
   const location = 'Sydney'
 
   // Optional
-  const device = 'iPhone8'
+  const device = 'iPhone12'
   const connection = 'good3G'
   const isPrivate = false
   const cookies = [

--- a/examples/nodejs/create-test.js
+++ b/examples/nodejs/create-test.js
@@ -9,7 +9,7 @@ const createTest = async () => {
 
   // Optional
   const device = 'iPhone12'
-  const connection = 'good3G'
+  const connection = 'LTE'
   const isPrivate = false
   const cookies = [
     {

--- a/examples/nodejs/sites/create.js
+++ b/examples/nodejs/sites/create.js
@@ -31,6 +31,8 @@ const create = async () => {
   const testProfiles = [
     {
       name: 'Chrome Desktop',
+      device: 'Desktop',
+      connection: 'cable',
       cookies: [
         {
           name: 'app.sid',
@@ -43,9 +45,9 @@ const create = async () => {
       ]
     },
     {
-      name: 'iPhone 8, 3G',
-      device: 'iPhone8',
-      connection: 'good3G'
+      name: 'iPhone 12, 3G',
+      device: 'iPhone12',
+      connection: 'LTE'
     }
   ]
 

--- a/examples/nodejs/test-profiles/create-test-profile.js
+++ b/examples/nodejs/test-profiles/create-test-profile.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
-import { TestProfile } from "calibre";
+import { TestProfile } from 'calibre'
 
 const create = async () => {
   const profileParams = {
     site: 'calibre',
     name: 'Chrome Desktop',
+    device: 'Desktop',
+    connection: 'cable',
     cookies: [
       {
         name: 'app.sid',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calibre",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calibre",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "engines": {
     "node": ">= 14.18"
   },

--- a/src/api/device.js
+++ b/src/api/device.js
@@ -2,17 +2,20 @@ import { request } from './graphql.js'
 
 const LIST_QUERY = `
   query{
-    __type(name: "DeviceTag") {
-      enumValues {
-        name
-      }
+    emulatedDevices {
+      tag
+      title
+      screenWidth
+      screenHeight
+      type
+      isDeprecated
     }
   }
 `
 
 const list = async () => {
   const response = await request({ query: LIST_QUERY })
-  return response.__type.enumValues
+  return response.emulatedDevices
 }
 
 export { list }

--- a/src/api/device.js
+++ b/src/api/device.js
@@ -8,7 +8,7 @@ const LIST_QUERY = `
       screenWidth
       screenHeight
       type
-      isDeprecated
+      isDiscontinued
     }
   }
 `

--- a/src/cli/device-list.js
+++ b/src/cli/device-list.js
@@ -34,7 +34,7 @@ const main = async args => {
       type: row.type,
       'screen width': row.screenWidth,
       'screen height': row.screenHeight,
-      status: row.isDeprecated ? 'Deprecated' : 'Active'
+      status: row.isDiscontinued ? 'Discontinued' : 'Current'
     }
   })
 

--- a/src/cli/device-list.js
+++ b/src/cli/device-list.js
@@ -29,7 +29,12 @@ const main = async args => {
 
   const rows = index.map(row => {
     return {
-      identifier: chalk.cyan(row.name)
+      identifier: chalk.cyan(row.tag),
+      name: row.title,
+      type: row.type,
+      'screen width': row.screenWidth,
+      'screen height': row.screenHeight,
+      status: row.isDeprecated ? 'Deprecated' : 'Active'
     }
   })
 

--- a/src/cli/site/create-test-profile.js
+++ b/src/cli/site/create-test-profile.js
@@ -49,7 +49,8 @@ const describe = 'Add a Test Profile to a Site.'
 const builder = {
   site: options.site,
   device: {
-    describe: 'Choose the emulated test device.'
+    describe: 'Choose the emulated test device.',
+    default: 'Desktop'
   },
   connection: {
     describe: 'Choose the emulated network connection speed.'
@@ -65,7 +66,8 @@ const builder = {
     default: false
   },
   'cookie-jar': {
-    describe: 'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
+    describe:
+      'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
   },
   json: options.json
 }

--- a/src/cli/site/create.js
+++ b/src/cli/site/create.js
@@ -38,17 +38,18 @@ const main = async function (args) {
   const testProfiles = [
     {
       name: 'Chrome Desktop',
+      device: 'Desktop',
       connection: 'cable'
     },
     {
-      name: 'MotoG4, 3G connection',
-      device: 'MotorolaMotoG4',
-      connection: 'regular3G'
+      name: 'iPhone, 4G LTE',
+      device: 'iPhone12',
+      connection: 'LTE'
     },
     {
-      name: 'iPhone, 4G LTE',
-      device: 'iPhone8',
-      connection: 'LTE'
+      name: 'Motorola Moto G Power, 3G connection',
+      device: 'MotorolaMotoGPower',
+      connection: 'regular3G'
     }
   ]
 

--- a/src/cli/site/update-test-profile.js
+++ b/src/cli/site/update-test-profile.js
@@ -46,7 +46,8 @@ const main = async function (args) {
   }
 }
 const command = 'update-test-profile [options]'
-const describe = 'Update Test Profile settings. Only changes specified attributes.'
+const describe =
+  'Update Test Profile settings. Only changes specified attributes.'
 const builder = {
   uuid: {
     demandOption: true,
@@ -72,7 +73,8 @@ const builder = {
     default: false
   },
   'cookie-jar': {
-    describe: 'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
+    describe:
+      'Set cookies by specifying a path to a Netscape formatted cookie jar file.'
   }
 }
 

--- a/src/views/test-profile.js
+++ b/src/views/test-profile.js
@@ -42,7 +42,7 @@ ${profile.jsIsDisabled ? '• Javascript Disabled' : ''}
 ${profile.adBlockerIsEnabled ? '• Adblocker Enabled' : ''}
 
 ${cookies(profile.cookies)}
-  `
+  `.trim()
 }
 
 export default view


### PR DESCRIPTION
## What does this PR introduce?

Prior to this PR, CLI queried Calibre's GraphQL API for `DeviceTag` enums in order to list the accepted list of devices that can be emulated. There's now a dedicated `emulatedDevices` field available in the API, so this PR updates to use that instead.

- [x] Use `emulatedDevices` field instead of `DeviceTag` enums
- [x] Update all examples to use current recommended devices
- [x] Update `cli/site/create` to use new default Test Profiles
- [x] Update create test profile example script to always specify device & connection configuration
- [x] Bump to `5.0.2` release

### Prerequisites

- calibreapp/app#2864