### PR TITLE
🙅‍♂️ Return Pull Request Review with failure status when budgets fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ## 🧹 Housekeeping
 
 - Updates dependencies in response to latest security patches.
-- Swapped dependency `update-notifier` for `simple-update-notifier``, which has better smaller and less risky package supply chain.
+- Swapped dependency `update-notifier` for `simple-update-notifier`, which has better smaller and less risky package supply chain.
 - Swapped dependency `json2csv` (now deprecated) for same authors new package that is maintained.
 
 # 5.0.4 (2023-05-31)

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -248,7 +248,7 @@ Flags:
   * `--sha`: The source control revision of the deployed code. e.g.: 9c72279.,
   * `--configPath`: Path to a Calibre YAML config file.,
   * `--waitForResult`: Wait for pull request to be evaluated before returning. (boolean),
-  * `--failOnUnmetBudget`: Return command failure if any budget is exceeded. Helpful for CI/CD. (Requires --waitForResult to also be set.) (boolean),
+  * `--failOnUnmetBudget`: Return a command failure if any existing budget is exceeded. (Requires --waitForResult to be set.) (boolean),
   * `--json`: Outputs the results of the command in JSON format.,
   * `--markdown`: Outputs the results of the command in Markdown format.
 

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -248,6 +248,7 @@ Flags:
   * `--sha`: The source control revision of the deployed code. e.g.: 9c72279.,
   * `--configPath`: Path to a Calibre YAML config file.,
   * `--waitForResult`: Wait for pull request to be evaluated before returning. (boolean),
+  * `--failOnUnmetBudget`: Return command failure if any budget is exceeded. Helpful for CI/CD. (Requires --waitForResult to also be set.) (boolean),
   * `--json`: Outputs the results of the command in JSON format.,
   * `--markdown`: Outputs the results of the command in Markdown format.
 

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -41,6 +41,12 @@ Object {
     "list": [Function],
     "update": [Function],
   },
+  "PullRequestReview": Object {
+    "create": [Function],
+    "getPRReviewByBranch": [Function],
+    "list": [Function],
+    "waitForReviewCompletion": [Function],
+  },
   "Site": Object {
     "create": [Function],
     "destroy": [Function],

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ retrieveToken()
 export * as Site from './src/api/site.js'
 export * as Snapshot from './src/api/snapshot.js'
 export * as Test from './src/api/test.js'
+export * as PullRequestReview from './src/api/pull-request-review.js'
 export * as TestProfile from './src/api/test-profile.js'
 export * as Agent from './src/api/location.js'
 export * as Page from './src/api/page.js'

--- a/src/api/pull-request-review.js
+++ b/src/api/pull-request-review.js
@@ -38,6 +38,7 @@ const GET_PR_REVIEW_BY_BRANCH = `
           status
           branch
           markdownReport
+          metricBudgetStatus
         }
       }
     }

--- a/src/cli/site/create-pull-request-review.js
+++ b/src/cli/site/create-pull-request-review.js
@@ -113,7 +113,7 @@ const builder = {
   },
   failOnUnmetBudget: {
     describe:
-      'Return command failure if any budget is exceeded. Helpful for CI/CD. (Requires --waitForResult to also be set.)',
+      'Return a command failure if any existing budget is exceeded. (Requires --waitForResult to be set.)',
     type: 'boolean',
     default: false
   },


### PR DESCRIPTION
In this PR: 

- [x] Return CLI with negative response when budgets fail during a Pull Request Review
- [x] Expose `PullRequestReview` from package