### PR TITLE
🐛 Fix: `test create` report output

### DIFF
--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -83,7 +83,7 @@ const main = async function (args) {
       } else {
         if (test.status == 'completed') {
           spinner.succeed(`Test complete: ${formattedTestUrl}`)
-          console.log(formatTest(test))
+          console.log(formatTest(test.markdownReport))
         } else {
           spinner.fail('Test complete')
         }


### PR DESCRIPTION
In this PR:

- [x] Fixes a bug that caused `calibre test create` to return an error, rather than a formatted test report. 