### PR TITLE
🐛 Correct PR create command markdown output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 5.1.3 (2024-02-21)
+
+## 🐛 Bug fixes
+
+- Fixes markdown output for `calibre site create-pull-request-review` (#671).
+
+## 🧹 Housekeeping
+
+- Updates dependencies in response to latest dependabot updates.
+
 # 5.1.2 (2023-11-03)
 
 ## 🐛 Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "engines": {
     "node": ">= 14.18"
   },

--- a/src/cli/site/create-pull-request-review.js
+++ b/src/cli/site/create-pull-request-review.js
@@ -10,11 +10,11 @@ import { options } from '../../utils/cli.js'
 import formatMarkdownResult from '../../views/markdown.js'
 
 const print = function (args, pullRequestReviewResponse) {
-  if (args.json && !args.waitForResult) {
+  if (args.json) {
     return console.log(JSON.stringify(pullRequestReviewResponse, null, 2))
   }
 
-  if (args.markdown && !args.waitForResult) {
+  if (args.markdown) {
     return console.log(pullRequestReviewResponse.markdownReport)
   }
 


### PR DESCRIPTION
In this PR:

- [x] Corrects `create-pull-request-review` `--markdown` flag output†
- [x] Version bump to 5.1.3
- [x] Update changelog


† Using `--markdown` and `--waitForResult` previously resulted in a markdown string that included ANSI escape codes. This PR corrects that behavior. 