### PR TITLE
💤 Add single page test expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 6.0.0 (2024-12-11)
+
+## 🛠 Core
+
+- Introduces `--expiresAt` flag to `calibre test create`. You can use this flag to set an expiry date for the test. After the expiry date, the test will be automatically deleted. **Default expiration is 1 year from creation date**.
+
+## 🧹 Housekeeping
+
+- Updates dependencies in response to latest dependabot updates and security patches.
+
 # 5.2.0 (2024-08-29)
 
 ## 🛠 Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 🛠 Core
 
-- Introduces `--expiresAt` flag to `calibre test create`. You can use this flag to set an expiry date for the test. After the expiry date, the test will be automatically deleted. **Default expiration is 1 year from creation date**.
+- Tests created with `calibre test create` now expire after 1 year. Once expired, the test will be deleted. You can set a custom expiry date with the `--expiresAt` flag.
+- Adds `--expiresAt` flag to `calibre test create`. You can use this flag to set an expiry date for the test. After the expiry date, the test will be automatically deleted.
 
 ## 🧹 Housekeeping
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 🛠 Core
 
-- Tests created with `calibre test create` now expire after 1 year. Once expired, the test will be deleted. You can set a custom expiry date with the `--expiresAt` flag.
+- Tests created with `calibre test create` or `Test.create` now expire after 1 year. Once expired, the test will be deleted. You can set a custom expiry date with the `--expiresAt` flag.
 - Adds `--expiresAt` flag to `calibre test create`. You can use this flag to set an expiry date for the test. After the expiry date, the test will be automatically deleted.
 
 ## 🧹 Housekeeping

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -296,6 +296,7 @@ Flags:
   * `--webhookSecret`: Secret used to sign the webhook payload. Secret can be validated using `Calibre-HMAC-SHA256-Signature` HTTP header. See https://calibreapp.com/docs/integrations/webhooks#webhook-security-and-verification for more information.,
   * `--adblocker`: Turn adblocking on or off. (boolean),
   * `--private`: Make the results of a test private (only accessible by members of your Calibre organisation). (boolean),
+  * `--expiresAt`: Set a future UTC date time string (ISO8601). After this date, the test will be automatically deleted. (Min=24 hrs, Max=2 years) e.g.: 2025-12-31T23:59:59Z (Default: Expires 1 year from creation date.: `2025-12-11T09:33:38.806Z`) (string),
   * `--cookie-jar`: Set cookies by specifying a path to a Netscape formatted cookie jar file.,
   * `--headers`: Set HTTP headers by providing a path to a JSON file or a valid JSON key-value pairs.,
   * `--json`: Outputs the results of the command in JSON format.,

--- a/CLI_COMMANDS.md
+++ b/CLI_COMMANDS.md
@@ -296,7 +296,7 @@ Flags:
   * `--webhookSecret`: Secret used to sign the webhook payload. Secret can be validated using `Calibre-HMAC-SHA256-Signature` HTTP header. See https://calibreapp.com/docs/integrations/webhooks#webhook-security-and-verification for more information.,
   * `--adblocker`: Turn adblocking on or off. (boolean),
   * `--private`: Make the results of a test private (only accessible by members of your Calibre organisation). (boolean),
-  * `--expiresAt`: Set a future UTC date time string (ISO8601). After this date, the test will be automatically deleted. (Min=24 hrs, Max=2 years) e.g.: 2025-12-31T23:59:59Z (Default: Expires 1 year from creation date.: `2025-12-11T09:33:38.806Z`) (string),
+  * `--expiresAt`: Set a future UTC date time string (ISO8601). After this date, the test will be automatically deleted. (Min=24 hrs, Max=2 years) e.g.: 2025-12-31T23:59:59Z (Default: Expires 1 year from creation date.: `2025-12-11T09:55:39.255Z`) (string),
   * `--cookie-jar`: Set cookies by specifying a path to a Netscape formatted cookie jar file.,
   * `--headers`: Set HTTP headers by providing a path to a JSON file or a valid JSON key-value pairs.,
   * `--json`: Outputs the results of the command in JSON format.,
@@ -315,7 +315,7 @@ Flags:
 
 ### calibre test list
 
-List all previously run Single Page Tests (includes UUID, URL, device, connection, test location and status).
+List recent Single Page Tests (includes UUID, URL, device, connection, test location and status).
 
 Flags:
  

--- a/generate-cli-md.js
+++ b/generate-cli-md.js
@@ -16,10 +16,18 @@ const formatOptions = options => {
     return `Flags:
  ${optionKeys.map(key => {
    // eslint-disable-next-line security/detect-object-injection
-   const { describe, default: defaultValue, type } = options[key]
+   const {
+     describe,
+     default: defaultValue,
+     defaultDescription,
+     type
+     // eslint-disable-next-line security/detect-object-injection
+   } = options[key]
    return `
   * \`--${key}\`: ${describe}${
-    defaultValue ? ` (default: \`${defaultValue}\`)` : ''
+    defaultValue
+      ? ` (${defaultDescription ? defaultDescription : 'default'}: \`${defaultValue}\`)`
+      : ''
   }${type ? ` (${type})` : ''}`
  })}`
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calibre",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calibre",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calibre",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calibre",
-      "version": "5.3.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "engines": {
     "node": ">= 18"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "engines": {
     "node": ">= 18"
   },

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,8 +1,8 @@
 import { request } from './graphql.js'
 
 const CREATE_MUTATION = `
-  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!], $headers: [HeaderInput!], $adBlockerIsEnabled: Boolean, $isPrivate: Boolean, $webhookUrl: URL, $webhookSecret: String) {
-    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies, headers: $headers, adBlockerIsEnabled: $adBlockerIsEnabled, isPrivate: $isPrivate, webhookUrl: $webhookUrl, webhookSecret: $webhookSecret) {
+  mutation CreateSinglePageTest($url: URL!, $location: LocationTag!, $device: DeviceTag, $connection: ConnectionTag, $cookies: [CookieInput!], $headers: [HeaderInput!], $adBlockerIsEnabled: Boolean, $isPrivate: Boolean, $webhookUrl: URL, $webhookSecret: String, $expiresAt: ISO8601DateTime) {
+    createTest(url: $url, location: $location, device: $device, connection: $connection, cookies: $cookies, headers: $headers, adBlockerIsEnabled: $adBlockerIsEnabled, isPrivate: $isPrivate, webhookUrl: $webhookUrl, webhookSecret: $webhookSecret, expiresAt: $expiresAt) {
       uuid
       formattedTestUrl
     }
@@ -101,7 +101,8 @@ const create = async ({
   adblocker,
   isPrivate,
   webhookUrl,
-  webhookSecret
+  webhookSecret,
+  expiresAt
 }) => {
   const response = await request({
     query: CREATE_MUTATION,
@@ -114,7 +115,8 @@ const create = async ({
     adBlockerIsEnabled: adblocker,
     isPrivate,
     webhookUrl,
-    webhookSecret
+    webhookSecret,
+    expiresAt
   })
   return response.createTest
 }

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -102,7 +102,8 @@ const create = async ({
   isPrivate,
   webhookUrl,
   webhookSecret,
-  expiresAt
+  // Expire in 1 year
+  expiresAt = new Date(Date.now() + 31556952000).toISOString()
 }) => {
   const response = await request({
     query: CREATE_MUTATION,

--- a/src/cli/test/create.js
+++ b/src/cli/test/create.js
@@ -54,14 +54,24 @@ const main = async function (args) {
   try {
     new URL(args.url)
   } catch {
-    return new Error('Please enter a valid URL')
+    throw new Error('Please enter a valid URL')
   }
 
   if (args.webhookUrl) {
     try {
       new URL(args.webhookUrl)
     } catch {
-      return new Error('Please enter a valid webhook URL')
+      throw new Error('Please enter a valid webhook URL')
+    }
+  }
+
+  if (args.expiresAt) {
+    const date = new Date(args.expiresAt).valueOf()
+
+    if (isNaN(date)) {
+      throw new Error(
+        'Please enter a valid `expiresAt` ISO8601 date time string'
+      )
     }
   }
 
@@ -129,6 +139,13 @@ const builder = {
       'Make the results of a test private (only accessible by members of your Calibre organisation).',
     type: 'boolean',
     default: false
+  },
+  expiresAt: {
+    describe:
+      'Set a future UTC date time string (ISO8601). After this date, the test will be automatically deleted. (Min=24 hrs, Max=2 years) e.g.: 2025-12-31T23:59:59Z',
+    type: 'string',
+    default: new Date(Date.now() + 31556952000).toISOString(),
+    defaultDescription: 'Default: Expires 1 year from creation date.'
   },
   'cookie-jar': {
     describe:

--- a/src/cli/test/list.js
+++ b/src/cli/test/list.js
@@ -61,7 +61,7 @@ const main = async args => {
 
 const command = 'list'
 const describe =
-  'List all previously run Single Page Tests (includes UUID, URL, device, connection, test location and status).'
+  'List recent Single Page Tests (includes UUID, URL, device, connection, test location and status).'
 const handler = main
 const builder = {
   json: options.json


### PR DESCRIPTION
In this PR:

- [x] Add `expiresAt` to single page test creation
- [x] Update CHANGELOG
- [x] Bump major version (6.0.0)