### PR TITLE
📯 Maintenance release 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 6.1.0 (2024-12-11)
+
+## 🐛 Bug fixes
+
+- Fix plain text output for `calibre site metrics` command.
+
+## 🧹 Housekeeping
+
+- Update `calibre site create` internal query.
+- Update & fix metric budget list example (`examples/nodejs/metric-budgets/list.js`).
+- Remove `changeThreshold` field from Metric Budget API responses, which has been deprecated.
+- Update dependencies in response to latest dependabot updates and security patches.
+
 # 6.0.0 (2024-12-11)
 
 ## 🛠 Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Update `calibre site create` internal query.
 - Update & fix metric budget list example (`examples/nodejs/metric-budgets/list.js`).
-- Remove `changeThreshold` field from Metric Budget API responses, which has been deprecated.
+- Remove `changeThreshold` field from Metric Budget API responses, which has been deprecated (Closes #792).
 - Update dependencies in response to latest dependabot updates and security patches.
 
 # 6.0.0 (2024-12-11)

--- a/examples/nodejs/metric-budgets/list.js
+++ b/examples/nodejs/metric-budgets/list.js
@@ -2,22 +2,29 @@
 
 import { MetricBudget } from 'calibre'
 
+// Returns a list of metric budgets for a site, including:
+// - The budget threshold value, e.g. 2500
+// - Budget status, e.g. "met", "unmet", "at_risk"
+// - Metric, e.g. "largestContentfulPaint"
+// - Each page and test profile associated with the budget, with:
+//   - Last observed value
+//   - Whether the budget is within the threshold
 const listMetricBudgets = async () => {
   const site = 'calibre' // site slug
-  const count = 20 // number of metric budgets to return, maximum 500
+  const count = 1 // number of metric budgets to return (maximum=5)
+  const metric = 'largestContentfulPaint' // specify a metric (default=budgets for all metrics are returned)
 
-  // Optional
-  const metric = 'consistently-interactive' // pass a metric to limit results
+  try {
+    const metricBudgets = await MetricBudget.list({
+      site,
+      metric,
+      count
+    })
 
-  // List the metric budgets
-  const metricBudgets = await MetricBudget.list({
-    site,
-    metric,
-    count
-  })
-
-  // Output the formatted JSON response
-  console.log(JSON.stringify(metricBudgets, null, 2))
+    console.log(JSON.stringify(metricBudgets, null, 2))
+  } catch (error) {
+    console.error(error)
+  }
 }
 
 listMetricBudgets()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calibre",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calibre",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@json2csv/node": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "calibre",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "engines": {
     "node": ">= 18"
   },

--- a/src/api/metric-budget.js
+++ b/src/api/metric-budget.js
@@ -7,7 +7,6 @@ const CREATE_MUTATION = `
       measurement
       value
       status
-      changeThreshold
 
       budgets {
         page {
@@ -40,7 +39,6 @@ const UPDATE_MUTATION = `
       measurement
       value
       status
-      changeThreshold
 
       budgets {
         page {
@@ -80,7 +78,6 @@ const LIST_QUERY = `
               measurement
               value
               status
-              changeThreshold
 
               metric {
                 name

--- a/src/api/site.js
+++ b/src/api/site.js
@@ -31,9 +31,13 @@ const CREATE_MUTATION = `
         uuid
       }
 
-      pages {
-        name
-        uuid
+      pagesList {
+        edges {
+          node {
+            name
+            uuid
+          }
+        }
       }
     }
   }

--- a/src/views/pulse-timeline.js
+++ b/src/views/pulse-timeline.js
@@ -6,7 +6,7 @@ import { format } from '../utils/formatters/index.js'
 const view = timeSeries => {
   const page = timeSeries.pages.map(page => page.name).join(', ')
 
-  const metrics = timeSeries.measurements.map(measurement => {
+  const metrics = timeSeries.metrics.map(measurement => {
     const series = timeSeries.series.filter(
       series => series.measurement === measurement.name
     )


### PR DESCRIPTION
In this PR:

- [x] Prepare `6.1.0` release & update changelog
- [x] Update GraphQL queries to cover recent deprecations
- [x] Update Metric budget list example